### PR TITLE
ci(ontology): update the myPy workflow yml file

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,4 +18,4 @@ jobs:
         pip install -r requirements-linux.txt
     - name: Analysing the code with mypy
       run: |
-        mypy pasta_eln/*.py
+        mypy pasta_eln


### PR DESCRIPTION
Adjusted the mypy invoke to pass the folder name where linting needs to be done, this it to disable the over-ride behavior of considering exclude flag from the configuration even for file names specified explicitly