### PR TITLE
fix(ontology): save fails in ontology editor

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -30,7 +30,7 @@ from .reorder_column_delegate import ReorderColumnDelegate
 from .required_column_delegate import RequiredColumnDelegate
 from .utility_functions import adjust_ontology_data_to_v3, show_message, \
   get_next_possible_structural_level_label, get_types_for_display, adapt_type, generate_empty_type, \
-  generate_required_properties, check_ontology_document, get_missing_props_message
+  generate_required_properties, check_ontology_types, get_missing_props_message
 
 
 class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
@@ -69,7 +69,6 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
       raise OntologyDocumentNullException("Null document passed for ontology data", {})
 
     self.ontology_document: Document = ontology_document
-    adjust_ontology_data_to_v3(self.ontology_document)
 
     # Instantiates property & attachment table models along with the column delegates
     self.props_table_data_model = OntologyPropsTableViewModel()
@@ -252,7 +251,6 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
         and selected_type in self.ontology_document):
       self.logger.info("User deleted the selected type: {%s}", selected_type)
       self.ontology_types.pop(selected_type)
-      self.ontology_document.pop(selected_type)
       self.typeComboBox.clear()
       self.typeComboBox.addItems(get_types_for_display(self.ontology_types.keys()))
       self.typeComboBox.setCurrentIndex(0)
@@ -355,7 +353,8 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     # Load the ontology types from the db document
     for data in self.ontology_document:
       if isinstance(self.ontology_document[data], dict):
-        self.ontology_types[data] = self.ontology_document[data]
+        self.ontology_types[data] = dict(self.ontology_document[data])
+    adjust_ontology_data_to_v3(self.ontology_types)
     self.ontology_loaded = True
 
     # Set the types in the type selector combo-box
@@ -368,11 +367,19 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     Save the modified ontology document data in database
     """
     self.logger.info("User clicked the save button..")
-    if missing_properties := check_ontology_document(self.ontology_document):
+    if missing_properties := check_ontology_types(self.ontology_types):
       message = get_missing_props_message(missing_properties)
       show_message(message)
       self.logger.warning(message)
       return
+    # Clear all the data from the ontology_document
+    for data in list(self.ontology_document.keys()):
+      if isinstance(self.ontology_document[data], dict):
+        del self.ontology_document[data]
+    # Copy all the modifications
+    for type_name, type_structure in self.ontology_types.items():
+      self.ontology_document[type_name] = type_structure
+    # Save the modified document
     self.ontology_document.save()
     show_message("Ontology data saved successfully..")
 
@@ -401,7 +408,6 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
       self.logger.info("User created a new type and added "
                        "to the ontology document: Title: {%s}, Label: {%s}", title, label)
       empty_type = generate_empty_type(label)
-      self.ontology_document[title] = empty_type
       self.ontology_types[title] = empty_type
       self.typeComboBox.clear()
       self.typeComboBox.addItems(get_types_for_display(self.ontology_types.keys()))

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -30,7 +30,7 @@ from .reorder_column_delegate import ReorderColumnDelegate
 from .required_column_delegate import RequiredColumnDelegate
 from .utility_functions import adjust_ontology_data_to_v3, show_message, \
   get_next_possible_structural_level_label, get_types_for_display, adapt_type, generate_empty_type, \
-  generate_required_properties
+  generate_required_properties, check_ontology_document, get_missing_props_message
 
 
 class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
@@ -368,6 +368,11 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     Save the modified ontology document data in database
     """
     self.logger.info("User saved the ontology data document!!")
+    if missing_properties := check_ontology_document(self.ontology_document):
+      message = get_missing_props_message(missing_properties)
+      show_message(message)
+      self.logger.warning(f"Missing required properties: \n {missing_properties}")
+      return
     self.ontology_document.save()
     show_message("Ontology data saved successfully..")
 

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -1,4 +1,5 @@
 """ OntologyConfigurationForm which is extended from the Ui_OntologyConfigurationBaseForm """
+import copy
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2023
@@ -353,7 +354,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     # Load the ontology types from the db document
     for data in self.ontology_document:
       if isinstance(self.ontology_document[data], dict):
-        self.ontology_types[data] = dict(self.ontology_document[data])
+        self.ontology_types[data] = copy.deepcopy(self.ontology_document[data])
     adjust_ontology_data_to_v3(self.ontology_types)
     self.ontology_loaded = True
 

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -367,7 +367,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     """
     Save the modified ontology document data in database
     """
-    self.logger.info("User saved the ontology data document!!")
+    self.logger.info("User clicked the save button..")
     if missing_properties := check_ontology_document(self.ontology_document):
       message = get_missing_props_message(missing_properties)
       show_message(message)

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -371,7 +371,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     if missing_properties := check_ontology_document(self.ontology_document):
       message = get_missing_props_message(missing_properties)
       show_message(message)
-      self.logger.warning(f"Missing required properties: \n {missing_properties}")
+      self.logger.warning(message)
       return
     self.ontology_document.save()
     show_message("Ontology data saved successfully..")

--- a/pasta_eln/GUI/ontology_configuration/ontology_tableview_data_model.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_tableview_data_model.py
@@ -202,7 +202,7 @@ class OntologyTableViewModel(QAbstractTableModel):
       self.logger.warning("Invalid position: {%s}", position)
       return None
     shift_position = position - 1
-    shift_position = shift_position if shift_position > 0 else 0
+    shift_position = max(shift_position, 0)
     self.data_set.insert(shift_position, data_to_be_pushed)
     self.logger.info("Reordered the data, Actual position: {%s}, "
                      "New Position: {%s}, "

--- a/pasta_eln/GUI/ontology_configuration/utility_functions.py
+++ b/pasta_eln/GUI/ontology_configuration/utility_functions.py
@@ -204,12 +204,12 @@ def generate_required_properties() -> list[dict[str, Any]]:
   return [
     {
       "name": "-name",
-      "query": "What is the name of the project?",
+      "query": "What is the name of the property?",
       "required": True
     },
     {
       "name": "-tags",
-      "query": "What are the tags associated with the project?",
+      "query": "What are the tags associated with this property?",
       "required": True
     }
   ]
@@ -240,7 +240,7 @@ def check_ontology_document(ontology_document: Document) -> dict[str, dict[str, 
         else type_name
       if type_structure.get("prop"):
         for category, properties in type_structure.get("prop").items():
-          names = [prop["name"] for prop in properties]
+          names = [prop.get("name") for prop in properties]
           for req_property in required_properties:
             if req_property not in names:
               if type_name not in types_with_missing_properties:

--- a/pasta_eln/fixedStringsJson.py
+++ b/pasta_eln/fixedStringsJson.py
@@ -1,58 +1,57 @@
 """ Long strings and dictionaries/JSON that would obfuscate code """
 from typing import Any
 
-defaultOntology:dict[str,Any] = {
-  "_id":"-ontology-",
-  "-version":3,
+defaultOntology: dict[str, Any] = {
+  "_id": "-ontology-",
+  "-version": 3,
 
-  "x0": {"IRI":"", "label":"Projects", "prop": {"default": [
-    {"name":"-name",    "query":"What is the name of the project?"},
-    {"name":"status",   "query":"What is the project status", "list":["active","paused","passive","finished"]},
-    {"name":"objective","query":"What is the objective?"},
-    {"name":"-tags"},
-    {"name":"comment",  "query":"#tags comments remarks :field:value:"}
+  "x0": {"IRI": "", "attachments": [], "label": "Projects", "prop": {"default": [
+    {"name": "-name", "query": "What is the name of the project?"},
+    {"name": "status", "query": "What is the project status", "list": ["active", "paused", "passive", "finished"]},
+    {"name": "objective", "query": "What is the objective?"},
+    {"name": "-tags"},
+    {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
-  "x1": {"IRI":"", "label":"Tasks", "prop": {"default": [
-    {"name":"-name",    "query":"What is the name of task?"},
-    {"name":"comment",  "query":"#tags comments remarks :field:value:"}
+  "x1": {"IRI": "", "attachments": [], "label": "Tasks", "prop": {"default": [
+    {"name": "-name", "query": "What is the name of task?"},
+    {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
-  "x2": {"IRI":"", "label":"Subtasks", "prop": {"default": [
-    {"name":"-name",    "query":"What is the name of subtask?"},
-    {"name":"comment",  "query":"#tags comments remarks :field:value:"}
+  "x2": {"IRI": "", "attachments": [], "label": "Subtasks", "prop": {"default": [
+    {"name": "-name", "query": "What is the name of subtask?"},
+    {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
 
-  "measurement": {"IRI":"", "label":"Measurements", "prop": {"default": [
-    {"name":"-name",       "query":"What is the file name?"},
-    {"name":"-tags"},
-    {"name":"comment",    "query":"#tags comments remarks :field:value:"},
-    {"name":"-type"},
-    {"name":"image"},
-    {"name":"#_curated"},
-    {"name":"sample",     "query":"Which sample was used?",     "list":"sample"},
-    {"name":"procedure",  "query":"Which procedure was used?",  "list":"procedure"}
+  "measurement": {"IRI": "", "attachments": [], "label": "Measurements", "prop": {"default": [
+    {"name": "-name", "query": "What is the file name?"},
+    {"name": "-tags"},
+    {"name": "comment", "query": "#tags comments remarks :field:value:"},
+    {"name": "-type"},
+    {"name": "image"},
+    {"name": "#_curated"},
+    {"name": "sample", "query": "Which sample was used?", "list": "sample"},
+    {"name": "procedure", "query": "Which procedure was used?", "list": "procedure"}
   ]}},
-  "sample": {"IRI":"", "label":"Samples", "prop": {"default": [
-    {"name":"-name",       "query":"What is the name / identifier of the sample?"},
-    {"name":"chemistry",  "query":"What is its chemical composition?"},
-    {"name":"-tags"},
-    {"name":"comment",    "query":"#tags comments remarks :field:value:"},
-    {"name":"qrCode"}
+  "sample": {"IRI": "", "attachments": [], "label": "Samples", "prop": {"default": [
+    {"name": "-name", "query": "What is the name / identifier of the sample?"},
+    {"name": "chemistry", "query": "What is its chemical composition?"},
+    {"name": "-tags"},
+    {"name": "comment", "query": "#tags comments remarks :field:value:"},
+    {"name": "qrCode"}
   ]}},
-  "procedure": {"IRI":"", "label":"Procedures", "prop": {"default": [
-    {"name":"-name",       "query":"What is the name / path?"},
-    {"name":"-tags"},
-    {"name":"comment",    "query":"#tags comments :field:value: e.g. #SOP_v1"},
-    {"name":"content",    "query":"What is procedure (Markdown possible; autofilled if file given)?"}
+  "procedure": {"IRI": "", "attachments": [], "label": "Procedures", "prop": {"default": [
+    {"name": "-name", "query": "What is the name / path?"},
+    {"name": "-tags"},
+    {"name": "comment", "query": "#tags comments :field:value: e.g. #SOP_v1"},
+    {"name": "content", "query": "What is procedure (Markdown possible; autofilled if file given)?"}
   ]}},
-  "instrument": {"IRI":"", "label":"Instruments", "prop": {"default": [
-    {"name":"-name",       "query":"What is the name / path?"},
-    {"name":"comment",    "query":"#tags comments :field:value: e.g. #SOP_v1"},
-    {"name":"vendor",     "query":"Who is the vendor?"}
+  "instrument": {"IRI": "", "attachments": [], "label": "Instruments", "prop": {"default": [
+    {"name": "-name", "query": "What is the name / path?"},
+    {"name": "comment", "query": "#tags comments :field:value: e.g. #SOP_v1"},
+    {"name": "vendor", "query": "Who is the vendor?"}
   ]}}
 }
 
-
-defaultOntologyNode:dict[str,list[dict[str,str]]] = {
+defaultOntologyNode: dict[str, list[dict[str, str]]] = {
   "default": [
     {"name": "-name", "query": "What is the file name?"},
     {"name": "-tags"},
@@ -60,8 +59,7 @@ defaultOntologyNode:dict[str,list[dict[str,str]]] = {
     {"name": "-type"}
   ]}
 
-
-defaultConfiguration:dict[str,Any] = {
+defaultConfiguration: dict[str, Any] = {
   "defaultProjectGroup": "research",
   "userID": "$os.getlogin()$",
   "version": 0,
@@ -69,24 +67,25 @@ defaultConfiguration:dict[str,Any] = {
   "qrPrinter": {},
   "extractorDir": "$(Path(__file__).parent/'Extractors').as_posix()$",
   "extractors": {},
-  "authors": [{"first":"", "last":"", "title":"", "email":"", "orcid":"","organizations":[{"organization":"", "rorid":""}]}],
+  "authors": [{"first": "", "last": "", "title": "", "email": "", "orcid": "",
+               "organizations": [{"organization": "", "rorid": ""}]}],
   "GUI": {},
   "projectGroups": {}
-  }
-
+}
 
 # level 1: type of property
 #   within each: array of 3: description, default, all_choices
-configurationGUI:dict[str,Any] = {
+configurationGUI: dict[str, Any] = {
   "general": {
     "theme": ["Theme",
               "light_blue",
-              ["dark_amber","dark_blue","dark_cyan","dark_lightgreen","dark_pink","dark_purple", "dark_red",\
-               "dark_teal","dark_yellow","light_amber","light_blue","light_cyan","light_cyan_500","light_lightgreen",\
-               "light_pink","light_purple","light_red","light_teal","light_yellow","none"]],
-    "loggingLevel": ["Logging level (more->less)","INFO",["DEBUG","INFO","WARNING","ERROR"]],
+              ["dark_amber", "dark_blue", "dark_cyan", "dark_lightgreen", "dark_pink", "dark_purple", "dark_red", \
+               "dark_teal", "dark_yellow", "light_amber", "light_blue", "light_cyan", "light_cyan_500",
+               "light_lightgreen", \
+               "light_pink", "light_purple", "light_red", "light_teal", "light_yellow", "none"]],
+    "loggingLevel": ["Logging level (more->less)", "INFO", ["DEBUG", "INFO", "WARNING", "ERROR"]],
   },
-  "dimensions":{
+  "dimensions": {
     "sidebarWidth": ["Sidebar width", 280, [220, 280, 340]],
     "maxTableColumnWidth": ["Maximum column width in tables", 400, [300, 400, 500, 600]],
     "imageSizeDetails": ["Image size in details view and form", 600, [300, 400, 500, 600]],
@@ -97,7 +96,6 @@ configurationGUI:dict[str,Any] = {
     "frameSize": ["Frame width around items in project view", 6, [4, 6, 8, 10]],
   }
 }
-
 
 setupTextLinux = """
 ### Welcome to the PASTA-ELN setup for Linux
@@ -110,7 +108,6 @@ This setup will analyse and (possibly) correct these items.
 
 If the installation is successful, manually and permanently remove the 'pastaELN.log' logfile that is in your home-directory.
 """
-
 
 setupTextWindows = """
 ### Welcome to the PASTA-ELN setup for Windows
@@ -178,7 +175,6 @@ This step helps to verify the installation and provides an helpful example for n
 This step usually takes up to 1min, so please be patient.
 """
 
-
 shortcuts = """
 Ctrl+Space: List projects
 Ctrl+M: List measurements
@@ -193,7 +189,6 @@ F9: Restart
 Ctrl+?: Verify database integrity
 Ctrl+0: Configuration
 """
-
 
 tableHeaderHelp = """
 <h4>You can add custom rows via bottom text area.</h4>

--- a/pasta_eln/fixedStringsJson.py
+++ b/pasta_eln/fixedStringsJson.py
@@ -6,24 +6,26 @@ defaultOntology: dict[str, Any] = {
   "-version": 3,
 
   "x0": {"IRI": "", "attachments": [], "label": "Projects", "prop": {"default": [
-    {"name": "-name", "query": "What is the name of the project?"},
+    {"name": "-name", "query": "What is the name of the project?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the project?", "required": True},
     {"name": "status", "query": "What is the project status", "list": ["active", "paused", "passive", "finished"]},
     {"name": "objective", "query": "What is the objective?"},
-    {"name": "-tags"},
     {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
   "x1": {"IRI": "", "attachments": [], "label": "Tasks", "prop": {"default": [
-    {"name": "-name", "query": "What is the name of task?"},
+    {"name": "-name", "query": "What is the name of task?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the task?", "required": True},
     {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
   "x2": {"IRI": "", "attachments": [], "label": "Subtasks", "prop": {"default": [
-    {"name": "-name", "query": "What is the name of subtask?"},
+    {"name": "-name", "query": "What is the name of subtask?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the subtask?", "required": True},
     {"name": "comment", "query": "#tags comments remarks :field:value:"}
   ]}},
 
   "measurement": {"IRI": "", "attachments": [], "label": "Measurements", "prop": {"default": [
-    {"name": "-name", "query": "What is the file name?"},
-    {"name": "-tags"},
+    {"name": "-name", "query": "What is the name of file name?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the file name?", "required": True},
     {"name": "comment", "query": "#tags comments remarks :field:value:"},
     {"name": "-type"},
     {"name": "image"},
@@ -32,20 +34,21 @@ defaultOntology: dict[str, Any] = {
     {"name": "procedure", "query": "Which procedure was used?", "list": "procedure"}
   ]}},
   "sample": {"IRI": "", "attachments": [], "label": "Samples", "prop": {"default": [
-    {"name": "-name", "query": "What is the name / identifier of the sample?"},
+    {"name": "-name", "query": "What is the name / identifier of the sample?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the sample?", "required": True},
     {"name": "chemistry", "query": "What is its chemical composition?"},
-    {"name": "-tags"},
     {"name": "comment", "query": "#tags comments remarks :field:value:"},
     {"name": "qrCode"}
   ]}},
   "procedure": {"IRI": "", "attachments": [], "label": "Procedures", "prop": {"default": [
-    {"name": "-name", "query": "What is the name / path?"},
-    {"name": "-tags"},
+    {"name": "-name", "query": "What is the name / path of the procedure?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the procedure?", "required": True},
     {"name": "comment", "query": "#tags comments :field:value: e.g. #SOP_v1"},
     {"name": "content", "query": "What is procedure (Markdown possible; autofilled if file given)?"}
   ]}},
   "instrument": {"IRI": "", "attachments": [], "label": "Instruments", "prop": {"default": [
-    {"name": "-name", "query": "What is the name / path?"},
+    {"name": "-name", "query": "What is the name / path of the instrument?", "required": True},
+    {"name": "-tags", "query": "What are the tags associated with the instrument?", "required": True},
     {"name": "comment", "query": "#tags comments :field:value: e.g. #SOP_v1"},
     {"name": "vendor", "query": "Who is the vendor?"}
   ]}}

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -167,7 +167,7 @@ class MainWindow(QMainWindow):
       report = self.comm.backend.replicateDB(progressBar=self.sidebar.progress)
       showMessage(self, 'Report of syncronization', report, style='QLabel {min-width: 450px}')
     elif command[0] is Command.ONTOLOGY:
-      ontologyForm = OntologyConfigurationForm(self.comm.backend.db.ontology)
+      ontologyForm = OntologyConfigurationForm(self.comm.backend.db.db['-ontology-'])
       ontologyForm.instance.exec()
     elif command[0] is Command.TEST1:
       fileName = QFileDialog.getOpenFileName(self, 'Open file for extractor test', str(Path.home()), '*.*')[0]

--- a/tests/app_tests/common/fixtures.py
+++ b/tests/app_tests/common/fixtures.py
@@ -136,10 +136,13 @@ def ontology_doc_mock(mocker) -> Document:
   mock_doc.__setitem__.side_effect = mock_doc_content.__setitem__
   mock_doc.__contains__.side_effect = mock_doc_content.__contains__
   mock_doc.__iter__.side_effect = mock_doc_content.__iter__
+  mock_doc.__delitem__.side_effect = mock_doc_content.__delitem__
+  mock_doc.pop.side_effect = mock_doc_content.pop
   mock_doc.keys.side_effect = mock_doc_content.keys
-  mock_doc.types.side_effect = mocker.MagicMock(return_value=dict((data, mock_doc_content[data])
-                                                                  for data in mock_doc_content
-                                                                  if type(mock_doc_content[data]) is dict))
+  mock_doc.types.side_effect = lambda: {
+    data: mock_doc_content[data]
+    for data in mock_doc_content if type(mock_doc_content[data]) is dict
+  }
   mock_doc.types_list.side_effect = mocker.MagicMock(return_value=[data for data in mock_doc_content
                                                                    if type(mock_doc_content[data]) is dict])
   return mock_doc

--- a/tests/app_tests/component_tests/test_ontology_configuration_extended.py
+++ b/tests/app_tests/component_tests/test_ontology_configuration_extended.py
@@ -1,19 +1,11 @@
-#  PASTA-ELN and all its sub-parts are covered by the MIT license.
-#
-#  Copyright (c) 2023
-#
-#  Author: Jithu Murugan
-#  Filename: test_ontology_configuration_extended.py
-#
-#  You should have received a copy of the license with this file. Please refer the license file for more information.
-
-#  PASTA-ELN and all its sub-parts are covered by the MIT license.
-#
-#
-#  Author: Jithu Murugan
-#  Filename: test_ontology_configuration_extended.py
-#
-#  You should have received a copy of the license with this file. Please refer the license file for more information.
+#   PASTA-ELN and all its sub-parts are covered by the MIT license.
+#  #
+#   Copyright (c) 2023
+#  #
+#   Author: Jithu Murugan
+#   Filename: test_ontology_configuration_extended.py
+#  #
+#   You should have received a copy of the license with this file. Please refer the license file for more information.
 
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt

--- a/tests/app_tests/test_data/ontology_document.json
+++ b/tests/app_tests/test_data/ontology_document.json
@@ -28,7 +28,8 @@
           "query": "What is the objective?"
         },
         {
-          "name": "-tags"
+          "name": "-tags",
+          "query": "What are the tags associated with this project?"
         },
         {
           "name": "comment",
@@ -42,6 +43,10 @@
           "required": "True",
           "IRI": "http://url.com",
           "unit": ""
+        },
+        {
+          "name": "-tags",
+          "query": "What are the tags associated with this project?"
         },
         {
           "name": "sample1",
@@ -64,6 +69,10 @@
           "query": "What is the name of task?"
         },
         {
+          "name": "-tags",
+          "query": "What are the tags associated with this task?"
+        },
+        {
           "name": "comment",
           "query": "#tags comments remarks :field:value:"
         }
@@ -79,6 +88,10 @@
         {
           "name": "-name",
           "query": "What is the name of subtask?"
+        },
+        {
+          "name": "-tags",
+          "query": "What are the tags associated with this subtask?"
         },
         {
           "name": "comment",
@@ -98,7 +111,8 @@
           "query": "What is the file name?"
         },
         {
-          "name": "-tags"
+          "name": "-tags",
+          "query": "What are the tags associated with this file name?"
         },
         {
           "name": "comment",
@@ -144,7 +158,8 @@
           "query": "What is its chemical composition?"
         },
         {
-          "name": "-tags"
+          "name": "-tags",
+          "query": "What are the tags associated with this sample?"
         },
         {
           "name": "comment",
@@ -167,7 +182,8 @@
           "query": "What is the name / path?"
         },
         {
-          "name": "-tags"
+          "name": "-tags",
+          "query": "What are the tags associated with this procedure?"
         },
         {
           "name": "comment",
@@ -190,6 +206,10 @@
           "name": "-name",
           "query": "What is the name / path?",
           "required": "True"
+        },
+        {
+          "name": "-tags",
+          "query": "What are the tags associated with this instruments?"
         },
         {
           "name": "comment",

--- a/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
@@ -459,7 +459,6 @@ class TestOntologyConfigConfiguration(object):
       configuration_extended.ontology_document.get.side_effect = ontology_document.get
       configuration_extended.ontology_document.keys.side_effect = ontology_document.keys
       configuration_extended.ontology_document.pop.side_effect = ontology_document.pop
-    pop_items_selected_ontology_document_spy = mocker.spy(configuration_extended.ontology_document, 'pop')
     if ontology_types:
       original_ontology_types = ontology_types.copy()
       configuration_extended.ontology_types.__setitem__.side_effect = ontology_types.__setitem__
@@ -482,7 +481,6 @@ class TestOntologyConfigConfiguration(object):
       if selected_type and selected_type in original_ontology_types and selected_type in original_ontology_document:
         logger_info_spy.assert_called_once_with("User deleted the selected type: {%s}", selected_type)
         pop_items_selected_ontology_types_spy.assert_called_once_with(selected_type)
-        pop_items_selected_ontology_document_spy.assert_called_once_with(selected_type)
         clear_category_combo_box_spy.assert_called_once_with()
         add_items_selected_spy.assert_called_once_with(
           get_types_for_display(ontology_types.keys())
@@ -493,7 +491,6 @@ class TestOntologyConfigConfiguration(object):
         logger_info_spy.assert_not_called()
         logger_info_spy.assert_not_called()
         pop_items_selected_ontology_types_spy.assert_not_called()
-        pop_items_selected_ontology_document_spy.assert_not_called()
         clear_category_combo_box_spy.assert_not_called()
         add_items_selected_spy.assert_not_called()
         set_current_index_category_combo_box_spy.assert_not_called()
@@ -676,15 +673,33 @@ class TestOntologyConfigConfiguration(object):
       else ontology_document
     mocker.patch.object(configuration_extended, 'ontology_document', create=True)
     if doc:
+      mocker.patch.object(configuration_extended, 'ontology_types', dict(ontology_document), create=True)
       configuration_extended.ontology_document.__setitem__.side_effect = doc.__setitem__
       configuration_extended.ontology_document.__getitem__.side_effect = doc.__getitem__
       configuration_extended.ontology_document.__iter__.side_effect = doc.__iter__
       configuration_extended.ontology_document.__contains__.side_effect = doc.__contains__
+      configuration_extended.ontology_document.__delitem__.side_effect = doc.__delitem__
+      configuration_extended.ontology_document.keys.side_effect = doc.keys
 
     mocker.patch.object(configuration_extended.logger, 'info')
     mock_show_message = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message')
+    mock_is_instance = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.isinstance')
+    mock_check_ontology_types = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types', return_value=None)
     assert configuration_extended.save_ontology() is None, "Nothing should be returned"
+
+    if doc:
+      for item in doc:
+        mock_is_instance.assert_any_call(doc[item], dict)
+        if isinstance(doc[item], dict):
+          configuration_extended.ontology_document.__delitem__.assert_any_call(item)
+      for item in configuration_extended.ontology_types:
+        configuration_extended.ontology_document.__setitem__.assert_any_call(item,
+                                                                             configuration_extended.ontology_types[
+                                                                               item])
+    mock_check_ontology_types.assert_called_once_with(configuration_extended.ontology_types)
     configuration_extended.logger.info.assert_called_once_with("User clicked the save button..")
     configuration_extended.ontology_document.save.assert_called_once()
     mock_show_message.assert_called_once_with("Ontology data saved successfully..")
@@ -693,7 +708,7 @@ class TestOntologyConfigConfiguration(object):
                                                                                    mocker,
                                                                                    ontology_doc_mock,
                                                                                    configuration_extended: configuration_extended):
-    mocker.patch.object(configuration_extended, 'ontology_document', create=True)
+    mocker.patch.object(configuration_extended, 'ontology_types', create=True)
     configuration_extended.ontology_document.__setitem__.side_effect = ontology_doc_mock.__setitem__
     configuration_extended.ontology_document.__getitem__.side_effect = ontology_doc_mock.__getitem__
     configuration_extended.ontology_document.__iter__.side_effect = ontology_doc_mock.__iter__
@@ -708,15 +723,15 @@ class TestOntologyConfigConfiguration(object):
       'Structure level 1': {'default': ['-tags']},
       'Structure level 2': {'default': ['-tags']},
       'instrument': {'default': ['-tags']}}
-    mock_check_ontology_document = mocker.patch(
-      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_document',
+    mock_check_ontology_document_types = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types',
       return_value=missing_props)
     mock_get_missing_props_message = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.get_missing_props_message',
       return_value="Missing message")
     assert configuration_extended.save_ontology() is None, "Nothing should be returned"
     log_info_spy.assert_called_once_with("User clicked the save button..")
-    mock_check_ontology_document.assert_called_once_with(configuration_extended.ontology_document)
+    mock_check_ontology_document_types.assert_called_once_with(configuration_extended.ontology_types)
     mock_get_missing_props_message.assert_called_once_with(missing_props)
     mock_show_message.assert_called_once_with("Missing message")
     log_warn_spy.assert_called_once_with("Missing message")
@@ -790,8 +805,6 @@ class TestOntologyConfigConfiguration(object):
                                               "to the ontology document: Title: {%s}, Label: {%s}", new_title,
                                               new_label)
 
-        (configuration_extended.ontology_document
-         .__setitem__.assert_called_once_with(new_title, generate_empty_type(new_label)))
         (configuration_extended.ontology_types
          .__setitem__.assert_called_once_with(new_title, generate_empty_type(new_label)))
         assert configuration_extended.typeComboBox.clear.call_count == 2, "ComboBox should be cleared twice"

--- a/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
@@ -357,6 +357,33 @@ class TestOntologyConfigUtilityFunctions(object):
          }
        }
      },
+     {'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}}),
+    ({
+       "x0": {
+       },
+       "x1": {
+         "prop": {
+           "default": [
+             {"name": "name", "query": "What is the name of task?"},
+             {"name": "-tags", "query": "What is the name of task?"},
+             {},
+             {}
+           ],
+           "category2": [
+             {"name": "-name", "query": "What is the name of task?"},
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"query": "What is the name of task?"}
+           ]
+         }
+       },
+       "test": {
+         "prop": {
+           "default": [
+             {"name": "-name", "query": "What is the name of task?"},
+           ]
+         }
+       }
+     },
      {'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}})
   ])
   def test_check_ontology_document_with_full_and_missing_properties_returns_expected_result(self,


### PR DESCRIPTION
- The ontology document has been passed directly to the ontology editor UI form instead of the dictionary and so the save can be called directly on a copy of types made from the document. Hence modified the logic to keep a copy of types from ontology document, edit them locally and then finally upon save, the document is cleared and all the changes are reflected in the document
- Added a check to see if the required properties [-name, -tags] are populated by the user before the save operation. If missing, then the save operation will not occur and the user will be prompted with a message to populate all the missing properties for all the property categories
- Corrected the fixedStringsJson.py to reflect the changes made for required properties
- Adjusted the tests to reflect the changes

Remark: Observe closely and monitor if any error (noticed by @SteffenBrinckmann) occurs when directly saving the ontology document in the near future or during the verification tests. If at all any failure observed, then this needs further investigation.