### PR TITLE
fix(ontology): added missing initDocTypeViews invoke to save function

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -70,12 +70,12 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
 
     # Gets the ontology data from db and adjust the data to the latest version
     if database is None:
-      raise OntologyConfigGenericException("Null database passed for ontology data", {})
+      raise OntologyConfigGenericException("Null database instance passed to the initializer", {})
 
     self.database: Database = database
     self.ontology_document: Document = self.database.db['-ontology-']
     if not self.ontology_document:
-      raise OntologyDocumentNullException("Null document passed for ontology data", {})
+      raise OntologyDocumentNullException("Null ontology document in db instance", {})
 
     # Instantiates property & attachment table models along with the column delegates
     self.props_table_data_model = OntologyPropsTableViewModel()

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -398,6 +398,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
       self.ontology_document[type_name] = type_structure
     # Save the modified document
     self.ontology_document.save()
+    self.database.ontology = dict(self.ontology_document)
     self.database.initDocTypeViews(16)
     show_message("Ontology data saved successfully..")
 

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -73,8 +73,8 @@ class MainWindow(QMainWindow):
     if hasattr(self.backend, 'configuration'):                            # not case in fresh install
       for name in self.backend.configuration['projectGroups'].keys():
         Action(name,                         self, [Command.CHANGE_PG, name], changeProjectGroups)
-    Action('&Syncronize',                    self, [Command.SYNC],            systemMenu, shortcut='F5')
-    Action('&Questionaires',                 self, [Command.ONTOLOGY],        systemMenu, shortcut='F8')
+    Action('&Synchronize',                    self, [Command.SYNC],            systemMenu, shortcut='F5')
+    Action('&Questionnaires',                 self, [Command.ONTOLOGY],        systemMenu, shortcut='F8')
     systemMenu.addSeparator()
     Action('&Test extraction from a file',   self, [Command.TEST1],           systemMenu)
     Action('Test &selected item extraction', self, [Command.TEST2],           systemMenu, shortcut='F2')
@@ -167,7 +167,7 @@ class MainWindow(QMainWindow):
       report = self.comm.backend.replicateDB(progressBar=self.sidebar.progress)
       showMessage(self, 'Report of syncronization', report, style='QLabel {min-width: 450px}')
     elif command[0] is Command.ONTOLOGY:
-      ontologyForm = OntologyConfigurationForm(self.comm.backend.db.db['-ontology-'])
+      ontologyForm = OntologyConfigurationForm(self.comm.backend.db)
       ontologyForm.instance.exec()
     elif command[0] is Command.TEST1:
       fileName = QFileDialog.getOpenFileName(self, 'Open file for extractor test', str(Path.home()), '*.*')[0]

--- a/tests/app_tests/component_tests/test_ontology_configuration_extended.py
+++ b/tests/app_tests/component_tests/test_ontology_configuration_extended.py
@@ -14,7 +14,7 @@ from pytestqt.qtbot import QtBot
 
 from pasta_eln.GUI.ontology_configuration.ontology_configuration_extended import OntologyConfigurationForm
 from pasta_eln.GUI.ontology_configuration.utility_functions import adapt_type, get_types_for_display
-from tests.app_tests.common.fixtures import ontology_editor_gui, ontology_doc_mock, props_column_names, \
+from tests.app_tests.common.fixtures import ontology_editor_gui, ontology_doc_mock, pasta_db_mock, props_column_names, \
   attachments_column_names
 
 

--- a/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
@@ -71,7 +71,7 @@ class TestOntologyConfigConfiguration(object):
     mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration.Ui_OntologyConfigurationBaseForm.setupUi')
     mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.adjust_ontology_data_to_v3')
     mocker.patch.object(QDialog, '__new__')
-    with pytest.raises(OntologyConfigGenericException, match="Null database passed for ontology data"):
+    with pytest.raises(OntologyConfigGenericException, match="Null database instance passed to the initializer"):
       OntologyConfigurationForm(None)
 
   def test_instantiation_with_database_with_null_document_should_throw_exception(self,
@@ -82,7 +82,7 @@ class TestOntologyConfigConfiguration(object):
     mocker.patch.object(QDialog, '__new__')
     mock_db = mocker.patch('pasta_eln.database.Database')
     mocker.patch.object(mock_db, 'db', {'-ontology-': None}, create=True)
-    with pytest.raises(OntologyDocumentNullException, match="Null document passed for ontology data"):
+    with pytest.raises(OntologyDocumentNullException, match="Null ontology document in db instance"):
       OntologyConfigurationForm(mock_db)
 
   @pytest.mark.parametrize("new_type_selected, mock_ontology_types", [

--- a/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
@@ -65,14 +65,25 @@ class TestOntologyConfigConfiguration(object):
     config_instance = OntologyConfigurationForm(mock_document)
     assert config_instance, "OntologyConfigurationForm should be created"
 
-  def test_instantiation_with_null_document_should_throw_exception(self,
+  def test_instantiation_with_null_database_should_throw_exception(self,
                                                                    mocker):
     mocker.patch('pasta_eln.GUI.ontology_configuration.create_type_dialog_extended.logging.getLogger')
     mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration.Ui_OntologyConfigurationBaseForm.setupUi')
     mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.adjust_ontology_data_to_v3')
     mocker.patch.object(QDialog, '__new__')
-    with pytest.raises(OntologyDocumentNullException, match="Null document passed for ontology data"):
+    with pytest.raises(OntologyConfigGenericException, match="Null database passed for ontology data"):
       OntologyConfigurationForm(None)
+
+  def test_instantiation_with_database_with_null_document_should_throw_exception(self,
+                                                                                 mocker):
+    mocker.patch('pasta_eln.GUI.ontology_configuration.create_type_dialog_extended.logging.getLogger')
+    mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration.Ui_OntologyConfigurationBaseForm.setupUi')
+    mocker.patch('pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.adjust_ontology_data_to_v3')
+    mocker.patch.object(QDialog, '__new__')
+    mock_db = mocker.patch('pasta_eln.database.Database')
+    mocker.patch.object(mock_db, 'db', {'-ontology-': None}, create=True)
+    with pytest.raises(OntologyDocumentNullException, match="Null document passed for ontology data"):
+      OntologyConfigurationForm(mock_db)
 
   @pytest.mark.parametrize("new_type_selected, mock_ontology_types", [
     ("x0", {
@@ -690,6 +701,8 @@ class TestOntologyConfigConfiguration(object):
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.isinstance')
     mock_check_ontology_types = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types', return_value=None)
+    mock_db_init_views = mocker.patch.object(configuration_extended.database,
+                                             'initDocTypeViews', return_value=None)
     assert configuration_extended.save_ontology() is None, "Nothing should be returned"
 
     if doc:
@@ -704,6 +717,7 @@ class TestOntologyConfigConfiguration(object):
     mock_check_ontology_types.assert_called_once_with(configuration_extended.ontology_types)
     configuration_extended.logger.info.assert_called_once_with("User clicked the save button..")
     configuration_extended.ontology_document.save.assert_called_once()
+    mock_db_init_views.assert_called_once_with(16)
     mock_show_message.assert_called_once_with("Ontology data saved successfully..")
 
   def test_save_ontology_with_missing_properties_should_skip_save_and_show_message(self,
@@ -826,15 +840,15 @@ class TestOntologyConfigConfiguration(object):
     mock_new_app_inst = mocker.patch("PySide6.QtWidgets.QApplication")
     mock_exist_app_inst = mocker.patch("PySide6.QtWidgets.QApplication")
     mock_form_instance = mocker.patch("PySide6.QtWidgets.QDialog")
-    mock_document = mocker.patch("cloudant.document.Document")
+    mock_database = mocker.patch("pasta_eln.database.Database")
 
     mocker.patch.object(QApplication, 'instance', return_value=mock_exist_app_inst if instance_exists else None)
     mocker.patch.object(mock_form, 'instance', mock_form_instance, create=True)
     spy_new_app_inst = mocker.patch.object(QApplication, '__new__', return_value=mock_new_app_inst)
     spy_form_inst = mocker.patch.object(OntologyConfigurationForm, '__new__', return_value=mock_form)
 
-    (app, form_inst, form) = get_gui(mock_document)
-    spy_form_inst.assert_called_once_with(OntologyConfigurationForm, mock_document)
+    (app, form_inst, form) = get_gui(mock_database)
+    spy_form_inst.assert_called_once_with(OntologyConfigurationForm, mock_database)
     if instance_exists:
       assert app is mock_exist_app_inst, "Should return existing instance"
       assert form_inst is mock_form_instance, "Should return existing instance"


### PR DESCRIPTION
- Modified OntologyConfigurationForm to accept the database instance instead of Ontology document in order to make sure to invoke initDocTypeViews while saving the ontology document
- Corrected the tests to reflect the changes
- Minor refactoring