### PR TITLE
fix(ontology): enabled auto stretch for the property table

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -104,7 +104,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     for column_index, width in self.props_table_data_model.column_widths.items():
       self.typePropsTableView.setColumnWidth(column_index, width)
     # When resized, only stretch the query column of typePropsTableView
-    self.typePropsTableView.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+    self.typePropsTableView.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
 
     self.typeAttachmentsTableView.setItemDelegateForColumn(
       ATTACHMENT_TABLE_DELETE_COLUMN_INDEX,


### PR DESCRIPTION
- Enabled stretch strategy for the query column so that the whole table adjusts to the main window resize automatically