### PR TITLE
fix(ontology): introduced check for properties with empty names

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -408,11 +408,13 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     Save the modified ontology document data in database
     """
     self.logger.info("User clicked the save button..")
-    if missing_properties := check_ontology_types(self.ontology_types):
-      message = get_missing_props_message(missing_properties)
+    types_with_missing_properties, types_with_null_name_properties = check_ontology_types(self.ontology_types)
+    if types_with_missing_properties or types_with_null_name_properties:
+      message = get_missing_props_message(types_with_missing_properties, types_with_null_name_properties)
       show_message(message, QMessageBox.Warning)
       self.logger.warning(message)
       return
+
     # Clear all the data from the ontology_document
     for data in list(self.ontology_document.keys()):
       if isinstance(self.ontology_document[data], dict):

--- a/pasta_eln/GUI/ontology_configuration/utility_functions.py
+++ b/pasta_eln/GUI/ontology_configuration/utility_functions.py
@@ -10,13 +10,12 @@
 
 import logging
 import re
-from typing import Any
+from typing import Any, Tuple
 
 from PySide6.QtCore import QEvent
-from PySide6.QtGui import QMouseEvent
-from PySide6.QtWidgets import QStyleOptionViewItem, QMessageBox
+from PySide6.QtGui import QMouseEvent, Qt
+from PySide6.QtWidgets import QMessageBox, QStyleOptionViewItem
 from cloudant import CouchDB
-from cloudant.document import Document
 
 
 def is_click_within_bounds(event: QEvent,
@@ -76,6 +75,7 @@ def show_message(message: str,
   if message:
     msg_box = QMessageBox()
     msg_box.setWindowTitle("Ontology Editor")
+    msg_box.setTextFormat(Qt.RichText)
     msg_box.setIcon(icon)
     msg_box.setText(message)
     msg_box.exec()
@@ -214,19 +214,23 @@ def generate_required_properties() -> list[dict[str, Any]]:
   ]
 
 
-def check_ontology_types(ontology_types: dict[str, Any]) -> dict[str, dict[str, list[str]]]:
+def check_ontology_types(ontology_types: dict[str, Any]) \
+    -> Tuple[dict[str, dict[str, list[str]]], dict[str, list[str]]]:
   """
-  Check the ontology data to see if all the required properties ["-name", "-tags"] are present under all categories
+  Check the ontology data to see if all the required properties ["-name", "-tags"]
+  are present under all categories and also if all the properties have a name
   Args:
-    ontology_types (Document): Ontology types loaded from the database
+    ontology_types (dict[str, Any]): Ontology types loaded from the database
 
-  Returns (dict[str, dict[str, list[str]]]): Empty dictionary if all the required properties are present under all categories
-  otherwise returns a dictionary of types with categories missing required properties
+  Returns (Tuple[dict[str, dict[str, list[str]]], dict[str, str]]):
+    Empty tuple if all the required properties are present under all categories and all properties have a name
+    otherwise returns a tuple of types with categories missing required properties or names
 
   """
   if not ontology_types:
-    return {}
+    return {}, {}
   types_with_missing_properties: dict[str, dict[str, list[str]]] = {}
+  types_with_null_name_properties: dict[str, list[str]] = {}
   required_properties = ["-name", "-tags"]
   for type_name, type_structure in ontology_types.items():
     type_name = type_name.replace("x", "Structure level ") \
@@ -235,6 +239,10 @@ def check_ontology_types(ontology_types: dict[str, Any]) -> dict[str, dict[str, 
     if type_structure.get("prop"):
       for category, properties in type_structure.get("prop").items():
         names = [prop.get("name") for prop in properties]
+        if not all(n and not n.isspace() for n in names):
+          if type_name not in types_with_null_name_properties:
+            types_with_null_name_properties[type_name] = []
+          types_with_null_name_properties[type_name].append(category)
         for req_property in required_properties:
           if req_property not in names:
             if type_name not in types_with_missing_properties:
@@ -242,25 +250,40 @@ def check_ontology_types(ontology_types: dict[str, Any]) -> dict[str, dict[str, 
             if category not in types_with_missing_properties[type_name]:
               types_with_missing_properties[type_name][category] = []
             types_with_missing_properties[type_name][category].append(req_property)
-  return types_with_missing_properties
+  return types_with_missing_properties, types_with_null_name_properties
 
 
-def get_missing_props_message(missing_properties: dict[str, dict[str, list[str]]]) -> str:
+def get_missing_props_message(types_with_missing_properties: dict[str, dict[str, list[str]]],
+                              types_with_null_name_properties: dict[str, list[str]]) -> str:
   """
   Get formatted message for missing properties
   Args:
-    missing_properties (dict[str, dict[str, list[str]]]): Missing properties
+    types_with_null_name_properties (dict[str, str]): Type categories with missing property names
+    types_with_missing_properties (dict[str, dict[str, list[str]]]): Type categories with missing properties
 
-  Returns (str): Formatted message
+  Returns (str): Html formatted message
 
   """
-  if not missing_properties:
-    return ""
-  message = "Missing required properties: \t\t\t\n\n"
-  for type_name, categories in missing_properties.items():
-    message += f"Type: {type_name}\n"
-    for category, properties in categories.items():
-      message += f"\tCategory: {category}\n"
-      for property_name in properties:
-        message += f"\t\tMissing Property: {property_name}\n"
+  message = ""
+  if (not types_with_missing_properties
+      and not types_with_null_name_properties):
+    return message
+  message += "<html>"
+  if types_with_missing_properties:
+    message += "<b>Missing required properties: </b><ul>"
+    for type_name, categories in types_with_missing_properties.items():
+      for category, properties in categories.items():
+        for property_name in properties:
+          message += (f"<li>Type: <i style=\"color:Crimson\">{type_name}</i>&nbsp;&nbsp;"
+                      f"Category: <i style=\"color:Crimson\">{category}</i>&nbsp;&nbsp;"
+                      f"Property Name: <i style=\"color:Crimson\">{property_name}</i></li>")
+    message += "</ul>"
+  if types_with_null_name_properties:
+    message += "<b>Missing property names:</b><ul>"
+    for type_name, categories_list in types_with_null_name_properties.items():
+      for category in categories_list:
+        message += (f"<li>Type: <i style=\"color:Crimson\">{type_name}</i>&nbsp;&nbsp;"
+                    f"Category: <i style=\"color:Crimson\">{category}</i></li>")
+    message += "</ul>"
+  message += "</html>"
   return message

--- a/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
@@ -703,7 +703,8 @@ class TestOntologyConfigConfiguration(object):
     mock_is_instance = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.isinstance')
     mock_check_ontology_types = mocker.patch(
-      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types', return_value=None)
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types',
+      return_value=(None, None))
     mock_db_init_views = mocker.patch.object(configuration_extended.database,
                                              'initDocTypeViews', return_value=None)
     assert configuration_extended.save_ontology() is None, "Nothing should be returned"
@@ -737,11 +738,15 @@ class TestOntologyConfigConfiguration(object):
     log_warn_spy = mocker.patch.object(configuration_extended.logger, 'warning')
     mock_show_message = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message')
-    missing_props = {
-      'Structure level 0': {'category1': ['-tags']},
-      'Structure level 1': {'default': ['-tags']},
-      'Structure level 2': {'default': ['-tags']},
-      'instrument': {'default': ['-tags']}}
+    missing_props = ({
+                       'Structure level 0': {'category1': ['-tags']},
+                       'Structure level 1': {'default': ['-tags']},
+                       'Structure level 2': {'default': ['-tags']},
+                       'instrument': {'default': ['-tags']}},
+                     {
+                       'Structure level 0': ['category1', '-tags'],
+                       'instrument': ['category1', '-tags']
+                     })
     mock_check_ontology_document_types = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types',
       return_value=missing_props)
@@ -751,7 +756,7 @@ class TestOntologyConfigConfiguration(object):
     assert configuration_extended.save_ontology() is None, "Nothing should be returned"
     log_info_spy.assert_called_once_with("User clicked the save button..")
     mock_check_ontology_document_types.assert_called_once_with(configuration_extended.ontology_types)
-    mock_get_missing_props_message.assert_called_once_with(missing_props)
+    mock_get_missing_props_message.assert_called_once_with(missing_props[0], missing_props[1])
     mock_show_message.assert_called_once_with("Missing message", QMessageBox.Warning)
     log_warn_spy.assert_called_once_with("Missing message")
 

--- a/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
@@ -10,13 +10,13 @@
 import logging
 
 import pytest
-from PySide6.QtCore import QEvent
+from PySide6.QtCore import QEvent, Qt
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QMessageBox
 from cloudant import CouchDB
 
-from pasta_eln.GUI.ontology_configuration.utility_functions import is_click_within_bounds, adjust_ontology_data_to_v3, \
-  get_next_possible_structural_level_label, get_db, show_message, check_ontology_types, get_missing_props_message
+from pasta_eln.GUI.ontology_configuration.utility_functions import adjust_ontology_data_to_v3, check_ontology_types, \
+  get_db, get_missing_props_message, get_next_possible_structural_level_label, is_click_within_bounds, show_message
 
 
 class TestOntologyConfigUtilityFunctions(object):
@@ -211,10 +211,26 @@ class TestOntologyConfigUtilityFunctions(object):
     assert show_message("Valid message") is None, "show_message should return None"
     set_text_spy.assert_called_once_with(
       "Valid message")
-    assert mock_msg_box.exec.call_count == 1, "show_message should call exec()"
+    mock_msg_box.exec.assert_called_once_with()
+    mock_msg_box.setWindowTitle.assert_called_once_with("Ontology Editor")
+    mock_msg_box.setTextFormat.assert_called_once_with(Qt.RichText)
+    mock_msg_box.setIcon.assert_called_once_with(QMessageBox.Information)
+
+  def test_show_message_with_error_argument_shows_warning(self,
+                                                          mocker):
+    mock_msg_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
+    set_text_spy = mocker.spy(mock_msg_box, 'setText')
+    mocker.patch.object(QMessageBox, "__new__", lambda s: mock_msg_box)
+    assert show_message("Error message", QMessageBox.Warning) is None, "show_message should return None"
+    set_text_spy.assert_called_once_with(
+      "Error message")
+    mock_msg_box.exec.assert_called_once_with()
+    mock_msg_box.setWindowTitle.assert_called_once_with("Ontology Editor")
+    mock_msg_box.setTextFormat.assert_called_once_with(Qt.RichText)
+    mock_msg_box.setIcon.assert_called_once_with(QMessageBox.Warning)
 
   @pytest.mark.parametrize("ontology_types, expected_result", [
-    ({}, {}),
+    ({}, ({}, {})),
     ({
        "x0": {
          "prop": {
@@ -241,18 +257,23 @@ class TestOntologyConfigUtilityFunctions(object):
          }
        }
      },
-     {'Structure level 0': {'category1': ['-name', '-tags'], 'default': ['-name', '-tags']},
-      'Structure level 1': {'category2': ['-name', '-tags'], 'default': ['-name', '-tags']}}),
+     ({'Structure level 0': {'category1': ['-name', '-tags'], 'default': ['-name', '-tags']},
+       'Structure level 1': {'category2': ['-name', '-tags'], 'default': ['-name', '-tags']}},
+      {}
+      )),
     ({
        "x0": {
          "prop": {
            "default": [
              {"name": "name", "query": "What is the name of task?"},
-             {"name": "-tags", "query": "What is the name of task?"}
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": "    ", "query": "What is the name of task?"},
+             {"name": None, "query": "What is the name of task?"}
            ],
            "category1": [
              {"name": "-name", "query": "What is the name of task?"},
-             {"name": "tags", "query": "What is the name of task?"}
+             {"name": "tags", "query": "What is the name of task?"},
+             {"name": "", "query": "What is the name of task?"}
            ]
          }
        },
@@ -265,12 +286,19 @@ class TestOntologyConfigUtilityFunctions(object):
            "category2": [
              {"name": "name", "query": "What is the name of task?"},
              {"name": "-tags", "query": "What is the name of task?"}
+           ],
+           "category3": [
+             {"name": "name", "query": "What is the name of task?"},
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": "   ", "query": "What is the name of task?"}
            ]
          }
        }
      },
-     {'Structure level 0': {'category1': ['-tags'], 'default': ['-name']},
-      'Structure level 1': {'category2': ['-name']}}),
+     ({'Structure level 0': {'category1': ['-tags'], 'default': ['-name']},
+       'Structure level 1': {'category2': ['-name'], 'category3': ['-name']}},
+      {'Structure level 0': ['default', 'category1'],
+       'Structure level 1': ['category3']})),
     ({
        "x0": {
          "prop": {
@@ -298,17 +326,21 @@ class TestOntologyConfigUtilityFunctions(object):
          }
        }
      },
-     {'Structure level 0': {'category2': ['-name', '-tags']}}),
+     ({'Structure level 0': {'category2': ['-name', '-tags']}}, {})),
+
     ({
        "x0": {
          "prop": {
            "default": [
              {"name": "-name", "query": "What is the name of task?"},
-             {"name": "-tags", "query": "What is the name of task?"}
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": None, "query": "What is the name of task?"}
+
            ],
            "category1": [
              {"name": "-name", "query": "What is the name of task?"},
-             {"name": "-tags", "query": "What is the name of task?"}
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": None, "query": "What is the name of task?"}
            ]
          }
        },
@@ -316,16 +348,20 @@ class TestOntologyConfigUtilityFunctions(object):
          "prop": {
            "default": [
              {"name": "-name", "query": "What is the name of task?"},
-             {"name": "-tags", "query": "What is the name of task?"}
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": "", "query": "What is the name of task?"}
            ],
            "category2": [
              {"name": "-name", "query": "What is the name of task?"},
-             {"name": "-tags", "query": "What is the name of task?"}
+             {"name": "-tags", "query": "What is the name of task?"},
+             {"name": " ", "query": "What is the name of task?"}
            ]
          }
        }
      },
-     {}),
+     ({},
+      {'Structure level 0': ['default', 'category1'],
+       'Structure level 1': ['default', 'category2']})),
     ({
        "x0": {
        },
@@ -345,11 +381,13 @@ class TestOntologyConfigUtilityFunctions(object):
          "prop": {
            "default": [
              {"name": "-name", "query": "What is the name of task?"},
+             {"name": "", "query": "What is the name of task?"},
            ]
          }
        }
      },
-     {'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}}),
+     ({'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}},
+      {'test': ['default']})),
     ({
        "x0": {
        },
@@ -376,24 +414,36 @@ class TestOntologyConfigUtilityFunctions(object):
          }
        }
      },
-     {'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}})
+     ({'Structure level 1': {'default': ['-name']}, 'test': {'default': ['-tags']}},
+      {'Structure level 1': ['default', 'category2']}))
   ])
   def test_check_ontology_document_with_full_and_missing_properties_returns_expected_result(self,
                                                                                             ontology_types,
                                                                                             expected_result):
     assert check_ontology_types(ontology_types) == expected_result, "show_message should return None"
 
-  def test_check_ontology_document_with_null_doc_returns_empty_dict(self):
-    assert check_ontology_types(None) == {}, "check_ontology_document should return empty dict"
+  def test_check_ontology_document_with_null_doc_returns_empty_tuple(self):
+    assert check_ontology_types(None) == ({}, {}), "check_ontology_document should return empty tuple"
 
-  @pytest.mark.parametrize("missing_properties, expected_message", [
-    ({}, ""),
+  @pytest.mark.parametrize("missing_properties, missing_names, expected_message", [
+    ({}, {}, ""),
     ({'Structure level 0': {'category1': ['-name', '-tags'], 'default': ['-name', '-tags']},
       'Structure level 1': {'category2': ['-name', '-tags'], 'default': ['-name', '-tags']}},
-     'Missing required properties: \t\t\t\n\nType: Structure level 0\n\tCategory: category1\n\t\tMissing Property: -name\n\t\tMissing Property: -tags\n\tCategory: default\n\t\tMissing Property: -name\n\t\tMissing Property: -tags\nType: Structure level 1\n\tCategory: category2\n\t\tMissing Property: -name\n\t\tMissing Property: -tags\n\tCategory: default\n\t\tMissing Property: -name\n\t\tMissing Property: -tags\n'),
+     {'Structure level 0': ['default', 'category1'],
+      'Structure level 1': ['default', 'category2']},
+     "<html><b>Missing required properties: </b><ul><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li></ul><b>Missing property names:</b><ul><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i></li></ul></html>"),
+    ({'Structure level 0': {'category1': ['-name', '-tags'], 'default': ['-name', '-tags']},
+      'Structure level 1': {'category2': ['-name', '-tags'], 'default': ['-name', '-tags']}},
+     {},
+     "<html><b>Missing required properties: </b><ul><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-name</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i>&nbsp;&nbsp;Property Name: <i style=\"color:Crimson\">-tags</i></li></ul></html>"),
+    ({},
+     {'Structure level 0': ['default', 'category1'],
+      'Structure level 1': ['default', 'category2']},
+     "<html><b>Missing property names:</b><ul><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i></li><li>Type: <i style=\"color:Crimson\">Structure level 0</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category1</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">default</i></li><li>Type: <i style=\"color:Crimson\">Structure level 1</i>&nbsp;&nbsp;Category: <i style=\"color:Crimson\">category2</i></li></ul></html>")
   ])
   def test_get_formatted_missing_props_message_returns_expected_message(self,
                                                                         missing_properties,
+                                                                        missing_names,
                                                                         expected_message):
     assert get_missing_props_message(
-      missing_properties) == expected_message, "get_missing_props_message should return expected"
+      missing_properties, missing_names) == expected_message, "get_missing_props_message should return expected"


### PR DESCRIPTION
- Introduced a check if there are any properties with empty names, if so warn the users for the respective type categories before the save action
- Corrected and added tests