### PR TITLE
fix(ontology): deletion of structural level types & normal types

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -20,9 +20,6 @@ from PySide6.QtWidgets import QApplication, QLineEdit, QMessageBox
 from cloudant.document import Document
 
 from .create_type_dialog_extended import CreateTypeDialog
-from .delete_column_delegate import DeleteColumnDelegate
-from .iri_column_delegate import IriColumnDelegate
-from .lookup_iri_action import LookupIriAction
 from .ontology_attachments_tableview_data_model import OntologyAttachmentsTableViewModel
 from .ontology_config_generic_exception import OntologyConfigGenericException
 from .ontology_config_key_not_found_exception import \
@@ -35,6 +32,9 @@ from .ontology_document_null_exception import OntologyDocumentNullException
 from .ontology_props_tableview_data_model import OntologyPropsTableViewModel
 from .reorder_column_delegate import ReorderColumnDelegate
 from .required_column_delegate import RequiredColumnDelegate
+from .delete_column_delegate import DeleteColumnDelegate
+from .iri_column_delegate import IriColumnDelegate
+from .lookup_iri_action import LookupIriAction
 from .utility_functions import adapt_type, adjust_ontology_data_to_v3, can_delete_type, check_ontology_types, \
   generate_empty_type, \
   generate_required_properties, get_missing_props_message, get_next_possible_structural_level_label, \

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -448,7 +448,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
     if self.ontology_document is None or self.ontology_types is None:
       self.logger.error("Null ontology_document/ontology_types, erroneous app state")
       raise OntologyConfigGenericException("Null ontology_document/ontology_types, erroneous app state", {})
-    if title in self.ontology_document:
+    if title in self.ontology_types:
       show_message(f"Type (title: {title} label: {label}) cannot be added since it exists in DB already....")
     else:
       if title is None:
@@ -462,24 +462,29 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
       self.typeComboBox.clear()
       self.typeComboBox.addItems(get_types_for_display(self.ontology_types.keys()))
       self.typeComboBox.setCurrentIndex(len(self.ontology_types) - 1)
-      show_message(f"Type (title: {title} label: {label}) has been added....")
 
   def show_hide_attachments_table(self) -> None:
     """
-    Show/hide the attachments table and the add attachment button
+    Show/hide the attachment table and the add attachment button
     Returns: Nothing
     """
     self.typeAttachmentsTableView.setVisible(not self.typeAttachmentsTableView.isVisible())
     self.addAttachmentPushButton.setVisible(not self.addAttachmentPushButton.isVisible())
 
-  @Slot(int)
+  @Slot(str)
   def check_and_disable_delete_button(self,
                                       selected_type: str) -> None:
     """
-    Slot invoked to check and disable the delete button for the selected type
+    Slot to check and disable the "delete" button for the selected type
+    Args:
+      selected_type (str): Selected type: typesComboBox
+
+    Returns: Nothing
+
     """
-    self.logger.info("User checked and disabled the delete button")
-    self.deleteTypePushButton.setEnabled(can_delete_type(self.ontology_types.keys(), selected_type))
+    (self.deleteTypePushButton
+     .setEnabled(can_delete_type(self.ontology_types.keys(),
+                                 selected_type)))
 
 
 def get_gui(database: Database) -> tuple[

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -15,10 +15,14 @@ import webbrowser
 from typing import Any
 
 from PySide6 import QtWidgets
+from PySide6.QtCore import QObject, Signal, Slot
 from PySide6.QtWidgets import QApplication, QLineEdit, QMessageBox
 from cloudant.document import Document
 
 from .create_type_dialog_extended import CreateTypeDialog
+from .delete_column_delegate import DeleteColumnDelegate
+from .iri_column_delegate import IriColumnDelegate
+from .lookup_iri_action import LookupIriAction
 from .ontology_attachments_tableview_data_model import OntologyAttachmentsTableViewModel
 from .ontology_config_generic_exception import OntologyConfigGenericException
 from .ontology_config_key_not_found_exception import \
@@ -31,18 +35,17 @@ from .ontology_document_null_exception import OntologyDocumentNullException
 from .ontology_props_tableview_data_model import OntologyPropsTableViewModel
 from .reorder_column_delegate import ReorderColumnDelegate
 from .required_column_delegate import RequiredColumnDelegate
-from .delete_column_delegate import DeleteColumnDelegate
-from .iri_column_delegate import IriColumnDelegate
-from .lookup_iri_action import LookupIriAction
-from .utility_functions import adapt_type, adjust_ontology_data_to_v3, check_ontology_types, generate_empty_type, \
+from .utility_functions import adapt_type, adjust_ontology_data_to_v3, can_delete_type, check_ontology_types, \
+  generate_empty_type, \
   generate_required_properties, get_missing_props_message, get_next_possible_structural_level_label, \
   get_types_for_display, show_message
 from ...database import Database
 
 
-class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
+class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
   """ OntologyConfigurationForm class which is extended from the Ui_OntologyConfigurationBaseForm
   and contains the UI elements and related logic"""
+  type_changed_signal = Signal(str)
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -50,8 +53,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     """
     return super(OntologyConfigurationForm, cls).__new__(cls)
 
-  def __init__(self,
-               database: Database) -> None:
+  def __init__(self, database: Database) -> None:
     """
     Constructs the ontology data editor
 
@@ -61,6 +63,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     Raises:
       OntologyDocumentNullException: Raised when passed in argument @ontology_document is null.
     """
+    super().__init__()
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
     self.ontology_loaded: bool = False
@@ -147,6 +150,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     self.logger.info("New type selected in UI: {%s}", new_type_selected)
     self.clear_ui()
     new_type_selected = adapt_type(new_type_selected)
+    self.type_changed_signal.emit(new_type_selected)
     if new_type_selected and self.ontology_types:
       if new_type_selected not in self.ontology_types:
         raise OntologyConfigKeyNotFoundException(f"Key {new_type_selected} "
@@ -286,8 +290,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     if self.ontology_types is None or self.ontology_document is None:
       show_message("Load the ontology data first....")
       return
-    if (selected_type and selected_type in self.ontology_types
-        and selected_type in self.ontology_document):
+    if selected_type and selected_type in self.ontology_types:
       self.logger.info("User deleted the selected type: {%s}", selected_type)
       self.ontology_types.pop(selected_type)
       self.typeComboBox.clear()
@@ -382,6 +385,8 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
       self.attachments_table_data_model.delete_data)
     self.reorder_column_delegate_attach_table.re_order_signal.connect(self.attachments_table_data_model.re_order_data)
 
+    self.type_changed_signal.connect(self.check_and_disable_delete_button)
+
   def load_ontology_data(self) -> None:
     """
     Load button click event handler which loads the data in the UI
@@ -466,6 +471,15 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm):
     """
     self.typeAttachmentsTableView.setVisible(not self.typeAttachmentsTableView.isVisible())
     self.addAttachmentPushButton.setVisible(not self.addAttachmentPushButton.isVisible())
+
+  @Slot(int)
+  def check_and_disable_delete_button(self,
+                                      selected_type: str) -> None:
+    """
+    Slot invoked to check and disable the delete button for the selected type
+    """
+    self.logger.info("User checked and disabled the delete button")
+    self.deleteTypePushButton.setEnabled(can_delete_type(self.ontology_types.keys(), selected_type))
 
 
 def get_gui(database: Database) -> tuple[

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -451,7 +451,7 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
     if title in self.ontology_types:
       show_message(f"Type (title: {title} label: {label}) cannot be added since it exists in DB already....")
     else:
-      if title is None:
+      if not title:
         self.logger.warning("Enter non-null/valid title!!.....")
         show_message("Enter non-null/valid title!!.....")
         return

--- a/pasta_eln/GUI/ontology_configuration/utility_functions.py
+++ b/pasta_eln/GUI/ontology_configuration/utility_functions.py
@@ -287,3 +287,30 @@ def get_missing_props_message(types_with_missing_properties: dict[str, dict[str,
     message += "</ul>"
   message += "</html>"
   return message
+
+
+def can_delete_type(existing_types: list[str],
+                    selected_type: str) -> bool:
+  """
+  Check if the selected type can be deleted
+    - Non-structural types can be deleted always
+    - Structural type 'x0' cannot be deleted at all, the other structural types can
+    only be deleted if they are the last one in the hierarchy
+  Args:
+    existing_types (list[str]): List of existing types
+    selected_type (str): Selected type to be deleted
+
+  Returns (bool): True/False depending on whether the selected type can be deleted
+  """
+  if not selected_type:
+    return False
+  existing_types = [t for t in existing_types if t]
+  if not is_structural_level(selected_type):
+    return True
+  structural_types = list(filter(is_structural_level, existing_types))
+  if selected_type == 'x0':
+    return False
+  if selected_type not in structural_types:
+    return False
+  else:
+    return max(structural_types) == selected_type

--- a/tests/app_tests/common/fixtures.py
+++ b/tests/app_tests/common/fixtures.py
@@ -238,11 +238,13 @@ def pasta_db_mock(mocker, ontology_doc_mock) -> Database:
 
 
 @fixture()
-def ontology_editor_gui(request, pasta_db_mock) -> tuple[QApplication,
+def ontology_editor_gui(mocker, request, pasta_db_mock) -> tuple[QApplication,
 QtWidgets.QDialog,
 OntologyConfigurationForm,
 QtBot]:
+  mock_message_box = mocker.patch('pasta_eln.GUI.ontology_configuration.utility_functions.QMessageBox')
   app, ui_dialog, ui_form_extended = get_gui(pasta_db_mock)
+  mocker.patch.object(ui_form_extended, 'message_box', mock_message_box, create=True)
   qtbot: QtBot = QtBot(app)
   return app, ui_dialog, ui_form_extended, qtbot
 

--- a/tests/app_tests/common/fixtures.py
+++ b/tests/app_tests/common/fixtures.py
@@ -244,7 +244,7 @@ OntologyConfigurationForm,
 QtBot]:
   mock_message_box = mocker.patch('pasta_eln.GUI.ontology_configuration.utility_functions.QMessageBox')
   app, ui_dialog, ui_form_extended = get_gui(pasta_db_mock)
-  mocker.patch.object(ui_form_extended, 'message_box', mock_message_box, create=True)
+  mocker.patch.object(ui_form_extended, 'message_box', mock_message_box.return_value, create=True)
   qtbot: QtBot = QtBot(app)
   return app, ui_dialog, ui_form_extended, qtbot
 

--- a/tests/app_tests/component_tests/test_ontology_configuration_extended.py
+++ b/tests/app_tests/component_tests/test_ontology_configuration_extended.py
@@ -235,6 +235,65 @@ class TestOntologyConfigurationExtended(object):
     assert ui_form.typeComboBox.currentText() == "title", "Data type combo box should be newly added type title"
     assert ui_form.typeLabelLineEdit.text() == "label", "Data type combo box should be newly added type label"
 
+  def test_component_create_new_type_normal_type_with_empty_title_should_warn_user(self,
+                                                                                   mocker,
+                                                                                   ontology_editor_gui:
+                                                                                   tuple[
+                                                                                     QApplication,
+                                                                                     QtWidgets.QDialog,
+                                                                                     OntologyConfigurationForm,
+                                                                                     QtBot],
+                                                                                   ontology_doc_mock: ontology_doc_mock,
+                                                                                   props_column_names: props_column_names,
+                                                                                   attachments_column_names: attachments_column_names):
+
+    app, ui_dialog, ui_form, qtbot = ontology_editor_gui
+    mocker.patch.object(ui_form.logger, 'warning')
+
+    # Checking with empty title
+    assert ui_form.create_type_dialog.instance.isVisible() is False, "Create new type dialog should not be shown!"
+    assert ui_form.create_type_dialog.buttonBox.isVisible() is False, "Create new type dialog button box should not be shown!"
+    qtbot.mouseClick(ui_form.addTypePushButton, Qt.LeftButton)
+    with qtbot.waitExposed(ui_form.create_type_dialog.instance, timeout=200):
+      assert ui_form.create_type_dialog.instance.isVisible() is True, "Create new type dialog should be shown!"
+      assert ui_form.create_type_dialog.buttonBox.isVisible() is True, "Create new type dialog button box should be shown!"
+      assert ui_form.create_type_dialog.structuralLevelCheckBox.isChecked() is False, "structuralLevelCheckBox should be unchecked"
+      ui_form.create_type_dialog.titleLineEdit.setText("")
+      ui_form.create_type_dialog.labelLineEdit.setText("label")
+    qtbot.mouseClick(ui_form.create_type_dialog.buttonBox.button(ui_form.create_type_dialog.buttonBox.Ok),
+                     Qt.LeftButton)
+    assert ui_form.create_type_dialog.instance.isVisible() is False, "Create new type dialog should not be shown!"
+    ui_form.logger.warning.assert_called_once_with("Enter non-null/valid title!!.....")
+    ui_form.message_box.setText.assert_called_once_with('Enter non-null/valid title!!.....')
+    ui_form.message_box.exec.assert_called_once_with()
+    assert ui_form.typeComboBox.currentText() != "", "Data type combo box should not be empty title"
+    assert ui_form.typeLabelLineEdit.text() != "label", "Data type combo box should not be newly added type label"
+
+    # Checking with None title
+    assert ui_form.create_type_dialog.instance.isVisible() is False, "Create new type dialog should not be shown!"
+    assert ui_form.create_type_dialog.buttonBox.isVisible() is False, "Create new type dialog button box should not be shown!"
+    qtbot.mouseClick(ui_form.addTypePushButton, Qt.LeftButton)
+    with qtbot.waitExposed(ui_form.create_type_dialog.instance, timeout=200):
+      assert ui_form.create_type_dialog.instance.isVisible() is True, "Create new type dialog should be shown!"
+      assert ui_form.create_type_dialog.buttonBox.isVisible() is True, "Create new type dialog button box should be shown!"
+      assert ui_form.create_type_dialog.structuralLevelCheckBox.isChecked() is False, "structuralLevelCheckBox should be unchecked"
+      ui_form.create_type_dialog.titleLineEdit.setText(None)
+      ui_form.create_type_dialog.labelLineEdit.setText("label")
+    qtbot.mouseClick(ui_form.create_type_dialog.buttonBox.button(ui_form.create_type_dialog.buttonBox.Ok),
+                     Qt.LeftButton)
+    assert ui_form.create_type_dialog.instance.isVisible() is False, "Create new type dialog should not be shown!"
+    ui_form.logger.warning.assert_has_calls([
+      mocker.call("Enter non-null/valid title!!....."),
+      mocker.call("Enter non-null/valid title!!.....")])
+    ui_form.message_box.setText.assert_has_calls([
+      mocker.call("Enter non-null/valid title!!....."),
+      mocker.call("Enter non-null/valid title!!.....")])
+    ui_form.message_box.exec.assert_has_calls([
+      mocker.call(),
+      mocker.call()])
+    assert ui_form.typeComboBox.currentText() != None, "Data type combo box should not be None"
+    assert ui_form.typeLabelLineEdit.text() != "label", "Data type combo box should not be newly added type label"
+
   def test_component_create_new_type_reject_should_not_add_new_type_with_label(self,
                                                                                ontology_editor_gui:
                                                                                tuple[

--- a/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
@@ -15,7 +15,8 @@ from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QMessageBox
 from cloudant import CouchDB
 
-from pasta_eln.GUI.ontology_configuration.utility_functions import adjust_ontology_data_to_v3, check_ontology_types, \
+from pasta_eln.GUI.ontology_configuration.utility_functions import adjust_ontology_data_to_v3, can_delete_type, \
+  check_ontology_types, \
   get_db, get_missing_props_message, get_next_possible_structural_level_label, is_click_within_bounds, show_message
 
 
@@ -447,3 +448,25 @@ class TestOntologyConfigUtilityFunctions(object):
                                                                         expected_message):
     assert get_missing_props_message(
       missing_properties, missing_names) == expected_message, "get_missing_props_message should return expected"
+
+  @pytest.mark.parametrize("existing_types, selected_type, expected_result", [
+    (["x0", "x1", "x3", "samples", "instruments"], "test", True),
+    (["x0", "x1", "x3", "x4", "instruments"], "x5", False),
+    (["x0", "x1", "x3", "x4", "instruments"], "x0", False),
+    (["x0", "x1", "x3", "x4", "instruments"], "x4", True),
+    (["x0", "x1", "x3", "x4", "instruments"], "x3", False),
+    (["x0", "x1", "x3", "x4", "instruments"], "x0", False),
+    (["x0", "x1", "x3", "x4", "instruments"], "x1", False),
+    (["x0", "x1", "x3", "x4", "instruments"], "instruments", True),
+    (["x2", "x3", "x5", "x0", "instruments"], "x5", True),
+    (["x2", "x3", "x5", "x0", "x7", "", "samples"], "x7", True),
+    (["x2", "x3", "x5", "x0", "x7", "", "samples"], "x8", False),
+    (["x2", "x3", "x5", "x0", "x7", "", None], "x8", False),
+    (["x2", "x3", "x5", "x0", "x7", "", None], None, False)
+  ])
+  def test_can_delete_type_returns_expected(self,
+                                            existing_types,
+                                            selected_type,
+                                            expected_result):
+    assert can_delete_type(
+      existing_types, selected_type) == expected_result, "can_delete_type should return expected"


### PR DESCRIPTION
- Added logic to allow deletion of only "non-structural level types" and "structural level types" in a restrictive manner
- x0 cannot be deleted at all, x1 to xn can be deleted only in a fashion that the user can delete only one item (xn: n being largest) at a time
- Corrected the tests and also added more automated component levels tests