### PR TITLE
fix(ontology): consecutive save click throws console errors 

### DIFF
--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -420,18 +420,24 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
       self.logger.warning(message)
       return
 
-    # Clear all the data from the ontology_document
-    for data in list(self.ontology_document.keys()):
-      if isinstance(self.ontology_document[data], dict):
-        del self.ontology_document[data]
-    # Copy all the modifications
-    for type_name, type_structure in self.ontology_types.items():
-      self.ontology_document[type_name] = type_structure
-    # Save the modified document
-    self.ontology_document.save()
-    self.database.ontology = dict(self.ontology_document)
-    self.database.initDocTypeViews(16)
-    show_message("Ontology data saved successfully..")
+    result = show_message("Save will close the tool and restart the Pasta Application (Yes/No?)",
+                 QMessageBox.Question,
+                 QMessageBox.No | QMessageBox.Yes,
+                 QMessageBox.Yes)
+
+    if result == QMessageBox.Yes:
+      # Clear all the data from the ontology_document
+      for data in list(self.ontology_document.keys()):
+        if isinstance(self.ontology_document[data], dict):
+          del self.ontology_document[data]
+      # Copy all the modifications
+      for type_name, type_structure in self.ontology_types.items():
+        self.ontology_document[type_name] = type_structure
+      # Save the modified document
+      self.ontology_document.save()
+      self.database.ontology = dict(self.ontology_document)
+      self.database.initDocTypeViews(16)
+      self.instance.close()
 
   def create_new_type(self,
                       title: str,

--- a/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
+++ b/pasta_eln/GUI/ontology_configuration/ontology_configuration_extended.py
@@ -421,9 +421,9 @@ class OntologyConfigurationForm(Ui_OntologyConfigurationBaseForm, QObject):
       return
 
     result = show_message("Save will close the tool and restart the Pasta Application (Yes/No?)",
-                 QMessageBox.Question,
-                 QMessageBox.No | QMessageBox.Yes,
-                 QMessageBox.Yes)
+                          QMessageBox.Question,
+                          QMessageBox.No | QMessageBox.Yes,
+                          QMessageBox.Yes)
 
     if result == QMessageBox.Yes:
       # Clear all the data from the ontology_document

--- a/pasta_eln/GUI/ontology_configuration/utility_functions.py
+++ b/pasta_eln/GUI/ontology_configuration/utility_functions.py
@@ -62,12 +62,17 @@ def adjust_ontology_data_to_v3(ontology_types: dict[str, Any]) -> None:
 
 
 def show_message(message: str,
-                 icon: Any = QMessageBox.Information) -> None:
+                 icon: Any = QMessageBox.Information,
+                 standard_buttons: Any = QMessageBox.Ok,
+                 default_button: Any = QMessageBox.Ok) -> Any:
   """
   Displays a message to the user using QMessageBox
   Args:
-    icon (Any): Message box icon
     message (str): Message to be displayed
+    icon (Any): Message box icon
+    standard_buttons (Any): Standard buttons
+    default_button (Any): Default button
+
 
   Returns: Return None if message is empty otherwise displays the message
 
@@ -78,7 +83,9 @@ def show_message(message: str,
     msg_box.setTextFormat(Qt.RichText)
     msg_box.setIcon(icon)
     msg_box.setText(message)
-    msg_box.exec()
+    msg_box.setStandardButtons(standard_buttons)
+    msg_box.setDefaultButton(default_button)
+    return msg_box.exec()
 
 
 def get_next_possible_structural_level_label(existing_type_labels: Any) -> str | None:

--- a/pasta_eln/GUI/ontology_configuration/utility_functions.py
+++ b/pasta_eln/GUI/ontology_configuration/utility_functions.py
@@ -86,6 +86,7 @@ def show_message(message: str,
     msg_box.setStandardButtons(standard_buttons)
     msg_box.setDefaultButton(default_button)
     return msg_box.exec()
+  return None
 
 
 def get_next_possible_structural_level_label(existing_type_labels: Any) -> str | None:

--- a/tests/app_tests/component_tests/test_ontology_configuration_extended.py
+++ b/tests/app_tests/component_tests/test_ontology_configuration_extended.py
@@ -9,7 +9,7 @@
 
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication, QCheckBox
+from PySide6.QtWidgets import QApplication, QCheckBox, QMessageBox
 from pytestqt.qtbot import QtBot
 
 from pasta_eln.GUI.ontology_configuration.lookup_iri_action import LookupIriAction
@@ -403,7 +403,7 @@ class TestOntologyConfigurationExtended(object):
     app, ui_dialog, ui_form, qtbot = ontology_editor_gui
     assert ui_form.create_type_dialog.buttonBox.isVisible() is False, "Create new type dialog should not be shown!"
     mock_show_message = mocker.patch(
-      "pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message")
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message', return_value=QMessageBox.Yes)
     current_selected_type_category = ui_form.propsCategoryComboBox.currentText()
     previous_types_category_count = ui_form.propsCategoryComboBox.count()
     qtbot.mouseClick(ui_form.deletePropsCategoryPushButton, Qt.LeftButton)
@@ -414,7 +414,10 @@ class TestOntologyConfigurationExtended(object):
       f"Combo list should have {previous_types_category_count - 1} items!"
     qtbot.mouseClick(ui_form.saveOntologyPushButton, Qt.LeftButton)
     assert ontology_doc_mock.types() == ui_form.ontology_types, "Ontology document should be modified!"
-    mock_show_message.assert_called_once_with("Ontology data saved successfully..")
+    mock_show_message.assert_called_once_with('Save will close the tool and restart the Pasta Application (Yes/No?)',
+                                               QMessageBox.Question,
+                                               QMessageBox.No | QMessageBox.Yes,
+                                               QMessageBox.Yes)
 
   def test_component_iri_lookup_button_click_should_show_ontology_lookup_dialog_and_set_iris_on_accept(self,
                                                                                                        ontology_editor_gui:

--- a/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_configuration_extended.py
@@ -794,7 +794,7 @@ class TestOntologyConfigConfiguration(object):
 
     mocker.patch.object(configuration_extended.logger, 'info')
     mock_show_message = mocker.patch(
-      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message')
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message', return_value=QMessageBox.Yes)
     mock_is_instance = mocker.patch(
       'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.isinstance')
     mock_check_ontology_types = mocker.patch(
@@ -817,7 +817,62 @@ class TestOntologyConfigConfiguration(object):
     configuration_extended.logger.info.assert_called_once_with("User clicked the save button..")
     configuration_extended.ontology_document.save.assert_called_once()
     mock_db_init_views.assert_called_once_with(16)
-    mock_show_message.assert_called_once_with("Ontology data saved successfully..")
+    mock_show_message.assert_called_once_with('Save will close the tool and restart the Pasta Application (Yes/No?)',
+                                               QMessageBox.Question,
+                                               QMessageBox.No | QMessageBox.Yes,
+                                               QMessageBox.Yes)
+
+  @pytest.mark.parametrize("ontology_document",
+                           [None,
+                            {"x0": {"IRI": "x0"}, "": {"IRI": "x1"}},
+                            {"x0": {"IRI": "x0"}, "": {"IRI": "x1"}, 23: "test", "__id": "test"},
+                            {"test": ["test1", "test2", "test3"]}
+                            ])
+  def test_cancel_save_ontology_should_do_expected(self,
+                                            mocker,
+                                            ontology_document,
+                                            configuration_extended: configuration_extended,
+                                            request):
+    doc = request.getfixturevalue(ontology_document) \
+      if ontology_document and type(ontology_document) is str \
+      else ontology_document
+    mocker.patch.object(configuration_extended, 'ontology_document', create=True)
+    if doc:
+      mocker.patch.object(configuration_extended, 'ontology_types', dict(ontology_document), create=True)
+      configuration_extended.ontology_document.__setitem__.side_effect = doc.__setitem__
+      configuration_extended.ontology_document.__getitem__.side_effect = doc.__getitem__
+      configuration_extended.ontology_document.__iter__.side_effect = doc.__iter__
+      configuration_extended.ontology_document.__contains__.side_effect = doc.__contains__
+      configuration_extended.ontology_document.__delitem__.side_effect = doc.__delitem__
+      configuration_extended.ontology_document.keys.side_effect = doc.keys
+
+    mocker.patch.object(configuration_extended.logger, 'info')
+    mock_show_message = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.show_message', return_value=QMessageBox.No)
+    mock_is_instance = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.isinstance')
+    mock_check_ontology_types = mocker.patch(
+      'pasta_eln.GUI.ontology_configuration.ontology_configuration_extended.check_ontology_types',
+      return_value=(None, None))
+    mock_db_init_views = mocker.patch.object(configuration_extended.database,
+                                             'initDocTypeViews', return_value=None)
+    assert configuration_extended.save_ontology() is None, "Nothing should be returned"
+
+    if doc:
+      for item in doc:
+        mock_is_instance.assert_not_called()
+        if isinstance(doc[item], dict):
+          configuration_extended.ontology_document.__delitem__.assert_not_called()
+      for item in configuration_extended.ontology_types:
+        configuration_extended.ontology_document.__setitem__.assert_not_called()
+    mock_check_ontology_types.assert_called_once_with(configuration_extended.ontology_types)
+    configuration_extended.logger.info.assert_called_once_with("User clicked the save button..")
+    configuration_extended.ontology_document.save.assert_not_called()
+    mock_db_init_views.assert_not_called()
+    mock_show_message.assert_called_once_with('Save will close the tool and restart the Pasta Application (Yes/No?)',
+                                               QMessageBox.Question,
+                                               QMessageBox.No | QMessageBox.Yes,
+                                               QMessageBox.Yes)
 
   def test_save_ontology_with_missing_properties_should_skip_save_and_show_message(self,
                                                                                    mocker,

--- a/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
+++ b/tests/app_tests/unit_tests/test_ontology_config_utility_functions.py
@@ -209,7 +209,9 @@ class TestOntologyConfigUtilityFunctions(object):
     mock_msg_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
     set_text_spy = mocker.spy(mock_msg_box, 'setText')
     mocker.patch.object(QMessageBox, "__new__", lambda s: mock_msg_box)
-    assert show_message("Valid message") is None, "show_message should return None"
+    mock_exec = mocker.MagicMock()
+    mocker.patch.object(mock_msg_box, "exec", return_value=mock_exec)
+    assert show_message("Valid message") is mock_exec, "show_message should not be None"
     set_text_spy.assert_called_once_with(
       "Valid message")
     mock_msg_box.exec.assert_called_once_with()
@@ -222,7 +224,9 @@ class TestOntologyConfigUtilityFunctions(object):
     mock_msg_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
     set_text_spy = mocker.spy(mock_msg_box, 'setText')
     mocker.patch.object(QMessageBox, "__new__", lambda s: mock_msg_box)
-    assert show_message("Error message", QMessageBox.Warning) is None, "show_message should return None"
+    mock_exec = mocker.MagicMock()
+    mocker.patch.object(mock_msg_box, "exec", return_value=mock_exec)
+    assert show_message("Error message", QMessageBox.Warning) is mock_exec, "show_message should not be None"
     set_text_spy.assert_called_once_with(
       "Error message")
     mock_msg_box.exec.assert_called_once_with()


### PR DESCRIPTION
- Invoking database.initDocTypeViews consecutively leads to the error been thrown without clearing the cache, hence added logic to restart the application also whenever save button in clicked
- Modified the save functionality to prompt the user with a message to confirm the save operation since this will lead to the restart of the whole application
- Modified and corrected the tests associated with the save operation