### PR TITLE
Sb redo name has to be in table

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,6 @@
 name: pypi
 
+#pypi want to be pushed with a *new tag* that commit, next line ensures it happens
 on: [push, pull_request]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/pasta_eln/GUI/tableHeader.py
+++ b/pasta_eln/GUI/tableHeader.py
@@ -68,7 +68,7 @@ class TableHeader(QDialog):
     if command[0] is Command.ADD:
       self.selectedList += selectedLeft
     elif command[0] is Command.DELETE:
-      self.selectedList = [i for i in self.selectedList if i not in selectedRight ]
+      self.selectedList = [i for i in self.selectedList if i not in selectedRight or i in ['name'] ]
     elif command[0] is Command.MOVE_UP  and len(selectedRight)==1:
       oldIndex = self.selectedList.index(selectedRight[0])
       if oldIndex>0:


### PR DESCRIPTION
Fix #116: For some reason this previously fixed issue, was undo/unfixed on (2023-10-23) by myself. Reimplemented the same fix
Also adds a comment to the github-workflow