### PR TITLE
Sb less user interaction

### DIFF
--- a/pasta_eln/GUI/configGUI.py
+++ b/pasta_eln/GUI/configGUI.py
@@ -2,7 +2,7 @@
 import json
 from pathlib import Path
 from typing import Callable, Any
-from PySide6.QtWidgets import QWidget, QFormLayout  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import QWidget, QFormLayout, QVBoxLayout, QGroupBox, QLabel  # pylint: disable=no-name-in-module
 from ..miscTools import restart
 from ..guiStyle import TextButton, addRowList
 from ..guiCommunicate import Communicate
@@ -20,16 +20,18 @@ class ConfigurationGUI(QWidget):
     """
     super().__init__()
     self.comm = comm
-
     #GUI elements
     if hasattr(self.comm.backend, 'configuration'):
       onDisk = self.comm.backend.configuration['GUI']
-      self.mainL = QFormLayout(self)
-      for items  in configurationGUI.values():
+      mainL  = QVBoxLayout(self)
+      for label, items  in configurationGUI.items():
+        groupbox = QGroupBox(label)
+        mainL.addWidget(groupbox)
+        sectionL = QFormLayout(groupbox)
         for k,v in items.items():
           setattr(self, k,
-                  addRowList(self.mainL, label=v[0], default=str(onDisk[k]), itemList=[str(i) for i in v[2]]))
-      self.mainL.addRow('Save changes', TextButton('Save changes', self, [], None))
+                  addRowList(sectionL, label=v[0], default=str(onDisk[k]), itemList=[str(i) for i in v[2]]))
+      mainL.addWidget(TextButton('Save changes', self, [], None))
 
 
   def execute(self, _:list[Any]) -> None:

--- a/pasta_eln/database.py
+++ b/pasta_eln/database.py
@@ -54,8 +54,8 @@ class Database:
       if '-ontology-' in self.db:
         self.db['-ontology-'].delete()
     # temporary changes for version 2.5: remove afterwards: code does not harm but would be legacy then
-    testDocID = [doc['_id'] for doc in self.db if doc['_id'].startswith('x-')][0]
-    if '-gui' not in self.db[testDocID]:
+    testDocIDs = [doc['_id'] for doc in self.db if doc['_id'].startswith('x-')]
+    if testDocIDs and '-gui' not in self.db[testDocIDs[0]]:
       for doc in self.db:
         if doc['_id'].startswith('_') or doc['_id'].endswith('-'):
           continue

--- a/pasta_eln/database.py
+++ b/pasta_eln/database.py
@@ -48,8 +48,11 @@ class Database:
     if '-version' in self.dataHierarchy and self.dataHierarchy['-version'] < 4:
       logging.info('Convert ontology to V4.0')
       dataHierarchy_pre_to_V4(self.dataHierarchy)
-      self.db['-dataHierarchy-'].delete()
+      if '-dataHierarchy-' in self.db:
+        self.db['-dataHierarchy-'].delete()
       self.db.create_document(self.dataHierarchy)
+      if '-ontology-' in self.db:
+        self.db['-ontology-'].delete()
     if '-version' not in self.dataHierarchy or self.dataHierarchy['-version']!=4:
       print(F"**ERROR wrong dataHierarchy version: {self.dataHierarchy['-version']}")
       raise ValueError(f"Wrong dataHierarchy version {self.dataHierarchy['-version']}")
@@ -212,7 +215,12 @@ class Database:
     Returns:
         dict: json representation of document
     """
-    return dict(self.db[docID])
+    doc = self.db[docID]
+    if '-gui' not in doc:
+      logging.warning('Add gui attribute to doc %s',doc['_id'])
+      doc['-gui'] = [True, True]
+      doc.save()
+    return dict(doc)
 
 
   def saveDoc(self, doc:dict[str,Any]) -> dict[str,Any]:
@@ -804,9 +812,6 @@ class Database:
     outstring+= outputString(outputStyle,'h2','List all database entries')
     if repair:
       print('REPAIR MODE IS ON: afterwards, full-reload and create views')
-    ## loop all documents
-    if repair and '-ontology-' in self.db:
-      self.db['-ontology-'].delete()
     for doc in self.db:
       try:
         if '_design' in doc['_id']:
@@ -836,15 +841,6 @@ class Database:
         #   print(oldPath, '->', newPath)
         #   doc['-branch'][0]['path'] = newPath
         #   doc.save()
-
-        # change database to version 4
-        if '-gui' not in doc:
-          outstring+= outputString(outputStyle,'error',f"dch00: gui does not exist {doc['_id']}")
-          if repair:
-            doc['-gui'] = [True, True]
-            doc.save()
-
-
 
         #branch test
         if '-branch' not in doc:

--- a/pasta_eln/database.py
+++ b/pasta_eln/database.py
@@ -53,6 +53,10 @@ class Database:
       self.db.create_document(self.dataHierarchy)
       if '-ontology-' in self.db:
         self.db['-ontology-'].delete()
+      for doc in self.db:
+        if '-gui' not in doc:
+          doc['-gui'] = [True, True]
+          doc.save()
     if '-version' not in self.dataHierarchy or self.dataHierarchy['-version']!=4:
       print(F"**ERROR wrong dataHierarchy version: {self.dataHierarchy['-version']}")
       raise ValueError(f"Wrong dataHierarchy version {self.dataHierarchy['-version']}")
@@ -215,12 +219,7 @@ class Database:
     Returns:
         dict: json representation of document
     """
-    doc = self.db[docID]
-    if '-gui' not in doc:
-      logging.warning('Add gui attribute to doc %s',doc['_id'])
-      doc['-gui'] = [True, True]
-      doc.save()
-    return dict(doc)
+    return dict(self.db[docID])
 
 
   def saveDoc(self, doc:dict[str,Any]) -> dict[str,Any]:

--- a/pasta_eln/database.py
+++ b/pasta_eln/database.py
@@ -53,7 +53,12 @@ class Database:
       self.db.create_document(self.dataHierarchy)
       if '-ontology-' in self.db:
         self.db['-ontology-'].delete()
+    # temporary changes for version 2.5: remove afterwards: code does not harm but would be legacy then
+    testDocID = [doc['_id'] for doc in self.db if doc['_id'].startswith('x-')][0]
+    if '-gui' not in self.db[testDocID]:
       for doc in self.db:
+        if doc['_id'].startswith('_') or doc['_id'].endswith('-'):
+          continue
         if '-gui' not in doc:
           doc['-gui'] = [True, True]
           doc.save()

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -86,7 +86,6 @@ class MainWindow(QMainWindow):
     helpMenu = menu.addMenu("&Help")
     Action('&Website',                       self, [Command.WEBSITE],         helpMenu)
     Action('&Verify database',               self, [Command.VERIFY_DB],       helpMenu, shortcut='Ctrl+?')
-    Action('&Repair database',               self, [Command.REPAIR_DB],       helpMenu)
     Action('Shortcuts',                      self, [Command.SHORTCUTS],       helpMenu)
     # shortcuts for advanced usage (user should not need)
     QShortcut('F9', self, lambda: self.execute([Command.RESTART]))
@@ -197,14 +196,6 @@ class MainWindow(QMainWindow):
     elif command[0] is Command.VERIFY_DB:
       report = self.comm.backend.checkDB(outputStyle='html', minimal=True)
       showMessage(self, 'Report of database verification', report, style='QLabel {min-width: 800px}')
-    elif command[0] is Command.REPAIR_DB:
-      ret = QMessageBox.critical(self, 'Warning', 'Are you sure you want to repair the database as it can destroy information?', \
-                      QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes,  # type: ignore[operator]
-                      QMessageBox.StandardButton.No)
-      if ret==QMessageBox.StandardButton.Yes:
-        self.comm.backend.checkDB(outputStyle='html', minimal=True, repair=True)
-        showMessage(self, 'Report of database verification', 'Rerun verification to test success',
-                    style='QLabel {min-width: 800px}')
     elif command[0] is Command.SHORTCUTS:
       showMessage(self, 'Keyboard shortcuts', shortcuts)
 
@@ -266,9 +257,8 @@ class Command(Enum):
   CONFIG    = 12
   WEBSITE   = 13
   VERIFY_DB = 14
-  REPAIR_DB = 15
-  SHORTCUTS = 16
-  RESTART   = 17
+  SHORTCUTS = 15
+  RESTART   = 16
 
 
 def startMain() -> None:

--- a/pasta_eln/guiStyle.py
+++ b/pasta_eln/guiStyle.py
@@ -28,7 +28,10 @@ def getColor(backend:Backend, color:str) -> str:
     str: #123456 color code
   """
   if not hasattr(backend, 'configuration') or backend.configuration['GUI']['theme']=='none':
-    return '#000000'
+    if color=='primary':
+      return '#000000'
+    else:
+      return '#BBBBBB'
   themeName = backend.configuration['GUI']['theme']
   return get_theme(f'{themeName}.xml')[f'{color}Color']
 


### PR DESCRIPTION
If people update from a current version 2.4 to the future 2.5 version: data has to be adopted. Until now there is the repair button that the user has to press. This PR makes it automatic on the first access of the old data (when the data hierarchy is written), user has not to do anything