### PR TITLE
feat(terminology-service): implement standalone version

### DIFF
--- a/pasta_eln/GUI/data_hierarchy/terminology_lookup_dialog.py
+++ b/pasta_eln/GUI/data_hierarchy/terminology_lookup_dialog.py
@@ -154,8 +154,8 @@ class TerminologyLookupDialog(Ui_TerminologyLookupDialogBase):
                                      textwrap.fill(result['information'], width=100, max_lines=2),
                                      result['iri'])
           self.searchProgressBar.setValue((100 - self.searchProgressBar.value()) / 2)
-    if self.terminology_lookup_service.session_request_errors:
-      self.errorConsoleTextEdit.setText('\n'.join(self.terminology_lookup_service.session_request_errors))
+    if self.terminology_lookup_service.http_client.session_request_errors:
+      self.errorConsoleTextEdit.setText('\n'.join(self.terminology_lookup_service.http_client.session_request_errors))
       self.errorConsoleTextEdit.setVisible(True)
     self.searchProgressBar.setValue(100)
 
@@ -171,3 +171,12 @@ class TerminologyLookupDialog(Ui_TerminologyLookupDialogBase):
     self.errorConsoleTextEdit.clear()
     self.errorConsoleTextEdit.setVisible(False)
     self.selected_iris.clear()
+
+
+if __name__ == "__main__":
+  import sys
+
+  app = QtWidgets.QApplication(sys.argv)
+  ui = TerminologyLookupDialog()
+  ui.instance.show()
+  sys.exit(app.exec())

--- a/tests/unit_tests/test_data_hierarchy_terminology_lookup_dialog.py
+++ b/tests/unit_tests/test_data_hierarchy_terminology_lookup_dialog.py
@@ -290,13 +290,14 @@ class TestDataHierarchyTerminologyLookupDialog(object):
     mocker.patch.object(terminology_lookup_dialog_mock, 'terminology_lookup_service', mock_terminology_service,
                         create=True)
     mocker.patch.object(terminology_lookup_dialog_mock, 'terminologyLineEdit', mock_terminology_line_edit, create=True)
-    mocker.patch.object(mock_terminology_service, 'session_request_errors', None)
+    mocker.patch.object(mock_terminology_service.http_client, 'session_request_errors', None)
     mock_terminology_line_edit_text = mocker.patch.object(mock_terminology_line_edit, 'text',
                                                           return_value="search_term")
 
     mock_do_loop = mocker.MagicMock()
     mocker.patch.object(mock_terminology_service, 'do_lookup', return_value=mock_do_loop)
-    mocker.patch.object(mock_terminology_service, 'session_request_errors', ["error1", "error2", "error3", "error4"])
+    mocker.patch.object(mock_terminology_service.http_client, 'session_request_errors',
+                        ["error1", "error2", "error3", "error4"])
     mock_event_loop = mocker.MagicMock()
     mock_get_event_loop = mocker.patch('pasta_eln.GUI.data_hierarchy.terminology_lookup_dialog.get_event_loop',
                                        return_value=mock_event_loop)


### PR DESCRIPTION
- Added main function to terminology_lookup_dialog
- Modified terminology lookup service to use the AsyncHttpClient module.
- Modified tests for the changes.

Usage:
- python ~/pasta_eln/GUI/data_hierarchy/terminology_lookup_dialog.py