### PR TITLE
Rescale all text documents in details, when the splitter changes size

### DIFF
--- a/pasta_eln/GUI/details.py
+++ b/pasta_eln/GUI/details.py
@@ -22,7 +22,7 @@ class Details(QScrollArea):
     comm.testExtractor.connect(self.testExtractor)
     self.doc:dict[str,Any]  = {}
     self.docID= ''
-    self.rescaleTexts = []
+    self.rescaleTexts:list[QTextEdit] = []
 
     # GUI elements
     self.mainW, self.mainL = widgetAndLayout('V', None)
@@ -249,7 +249,7 @@ class Details(QScrollArea):
     self.metaDetailsW.setFixedWidth(width)
     for text in self.rescaleTexts:
       text.document().setTextWidth(width)
-      height:int = text.document().size().toTuple()[1] # type: ignore[index]
+      height:int = text.document().size().toTuple()[1]
       text.setFixedHeight(height)
     return
 

--- a/pasta_eln/GUI/details.py
+++ b/pasta_eln/GUI/details.py
@@ -22,6 +22,7 @@ class Details(QScrollArea):
     comm.testExtractor.connect(self.testExtractor)
     self.doc:dict[str,Any]  = {}
     self.docID= ''
+    self.rescaleTexts = []
 
     # GUI elements
     self.mainW, self.mainL = widgetAndLayout('V', None)
@@ -86,6 +87,7 @@ class Details(QScrollArea):
     self.btnVendor.setChecked(True)
     self.btnUser.setChecked(True)
     self.btnDatabase.setChecked(False)
+    self.rescaleTexts = []
     if not docID:  #if given '' docID, return
       return
     # Create new
@@ -155,7 +157,7 @@ class Details(QScrollArea):
       else:
         link = False
         dataHierarchyItem = [i for group in dataHierarchyNode for i in dataHierarchyNode[group] if i['name']==key]
-        if isinstance(self.doc[key],str) and '\n' in self.doc[key]:     #if returns in value: format nicely
+        if (isinstance(self.doc[key],str) and '\n' in self.doc[key]) or key=='comment':
           labelW, labelL = widgetAndLayout('H', self.metaDetailsL, top='s', bottom='s')
           labelL.addWidget(QLabel(f'{key}: '), alignment=Qt.AlignTop) # type: ignore
           text = QTextEdit()
@@ -165,6 +167,7 @@ class Details(QScrollArea):
           text.setStyleSheet(f"QTextEdit {{ border: none; padding: 0px; background-color: {bgColor}; "\
                                 f"color: {fgColor} }}")
           text.document().setTextWidth(labelW.width())
+          self.rescaleTexts.append(text)
           height:int = text.document().size().toTuple()[1] # type: ignore[index]
           text.setFixedHeight(height)
           text.setReadOnly(True)
@@ -234,6 +237,20 @@ class Details(QScrollArea):
     """
     logging.debug('used link on %s|%s',label,docID)
     self.comm.changeDetails.emit(docID)
+    return
+
+
+  def resizeWidth(self, width:int) -> None:
+    """ called if details is resized by splitter at the parent widget
+    - resize all text-documents
+    """
+    if not self.rescaleTexts:
+      return
+    self.metaDetailsW.setFixedWidth(width)
+    for text in self.rescaleTexts:
+      text.document().setTextWidth(width)
+      height:int = text.document().size().toTuple()[1] # type: ignore[index]
+      text.setFixedHeight(height)
     return
 
 

--- a/pasta_eln/GUI/details.py
+++ b/pasta_eln/GUI/details.py
@@ -249,7 +249,7 @@ class Details(QScrollArea):
     self.metaDetailsW.setFixedWidth(width)
     for text in self.rescaleTexts:
       text.document().setTextWidth(width)
-      height:int = text.document().size().toTuple()[1]
+      height:int = text.document().size().toTuple()[1] #type: ignore[index]
       text.setFixedHeight(height)
     return
 

--- a/pasta_eln/GUI/docTypes.py
+++ b/pasta_eln/GUI/docTypes.py
@@ -14,6 +14,7 @@ class DocTypes(QWidget):
     # GUI elements
     table = Table(comm)
     self.details = Details(comm)
+    self.details.resizeEvent = self.resizeWidget # type: ignore
     splitter = QSplitter()
     splitter.setHandleWidth(10)
     splitter.addWidget(table)
@@ -52,4 +53,10 @@ class DocTypes(QWidget):
     """
     if docID!='':
       self.details.show()
+    return
+
+
+  def resizeWidget(self, _) -> None:
+    """ called if splitter resizes details-view  """
+    self.details.resizeWidth(self.details.width())
     return

--- a/pasta_eln/GUI/docTypes.py
+++ b/pasta_eln/GUI/docTypes.py
@@ -1,4 +1,5 @@
 """ widget that shows the table and the details of the items """
+from typing import Any
 from PySide6.QtCore import Slot                                # pylint: disable=no-name-in-module
 from PySide6.QtWidgets import QWidget, QSplitter, QVBoxLayout  # pylint: disable=no-name-in-module
 from .table import Table
@@ -56,7 +57,7 @@ class DocTypes(QWidget):
     return
 
 
-  def resizeWidget(self, _) -> None:
+  def resizeWidget(self, _:Any) -> None:
     """ called if splitter resizes details-view  """
     self.details.resizeWidth(self.details.width())
     return

--- a/pasta_eln/GUI/project.py
+++ b/pasta_eln/GUI/project.py
@@ -119,6 +119,7 @@ class Project(QWidget):
     commentL.addWidget(self.commentTE)
     return
 
+
   def commentResize(self, _:Any) -> None:
     """ called if comment is resized because widget initially/finally knows its size
     - comment widget is hard coded size it depends on the rendered size

--- a/pasta_eln/handleDictionaries.py
+++ b/pasta_eln/handleDictionaries.py
@@ -181,7 +181,10 @@ def dict2ul(aDict:dict[str,Any]) -> str:
   text = '<ul>'
   for key, value in aDict.items():
     if isinstance(value,str) and value.startswith('{') and value.endswith('}'):
-      value = json.loads(value.replace("'",'"'))
+      try:
+        value = json.loads(value.replace("'",'"'))
+      except:
+        pass
     if isinstance(value, dict):
       valueString = dict2ul(value)
     elif isinstance(value, list):


### PR DESCRIPTION
Fix #98 
- Rescale all text documents in details, when the splitter changes size
- prevent crashes if dict2ul gets bad dictionary