### PR TITLE
Ignore configuration .pastaELN.json when restoring

### DIFF
--- a/pasta_eln/serverActions.py
+++ b/pasta_eln/serverActions.py
@@ -445,7 +445,7 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
       print(f'[{str(idx + 1)}] {i}')
     fileName = input(f'Which file to use for restored? (1-{len(possFiles)}) ')
     if fileName=='':
-      fileName=1
+      fileName = '1'
     fileName = possFiles[int(fileName)-1]
   # use information
   authUser = requests.auth.HTTPBasicAuth(userName, password)

--- a/pasta_eln/serverActions.py
+++ b/pasta_eln/serverActions.py
@@ -444,9 +444,7 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
     for idx, i in enumerate(possFiles):
       print(f'[{str(idx + 1)}] {i}')
     fileChoice = input(f'Which file to use for restored? (1-{len(possFiles)}) ')
-    if fileChoice=='':
-      fileChoice = '1'
-    fileName = possFiles[int(fileChoice)-1]
+    fileName = possFiles[int(fileChoice)-1] if fileChoice else possFiles[0]
   # use information
   authUser = requests.auth.HTTPBasicAuth(userName, password)
   with ZipFile(fileName, 'r', compression=ZIP_DEFLATED) as zipFile:

--- a/pasta_eln/serverActions.py
+++ b/pasta_eln/serverActions.py
@@ -444,6 +444,8 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
     for idx, i in enumerate(possFiles):
       print(f'[{str(idx + 1)}] {i}')
     fileName = input(f'Which file to use for restored? (1-{len(possFiles)}) ')
+    if fileName=='':
+      fileName=1
     fileName = possFiles[int(fileName)-1]
   # use information
   authUser = requests.auth.HTTPBasicAuth(userName, password)
@@ -452,6 +454,8 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
     #first run through: create documents and design documents
     for fileI in files:
       fileParts = fileI.split('/')[1:]
+      if fileParts==['pastaELN.json']: #do not recreate file, it is only there for manual recovery
+        continue
       database = fileParts[0]
       docID = fileParts[1]
       if docID.endswith('_attach'):
@@ -481,6 +485,8 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
     #second run through: create attachments
     for fileI in files:
       fileParts = fileI.split('/')[1:]
+      if fileParts==['pastaELN.json']: #do not recreate file, it is only there for manual recovery
+        continue
       database = fileParts[0]
       docID = fileParts[1]
       if not docID.endswith('_attach'):

--- a/pasta_eln/serverActions.py
+++ b/pasta_eln/serverActions.py
@@ -443,10 +443,10 @@ def restoreCouchDB(location:str='', userName:str='', password:str='', fileName:s
     possFiles = [i for i in os.listdir('.') if i.startswith('couchDB') and i.endswith('.zip')]
     for idx, i in enumerate(possFiles):
       print(f'[{str(idx + 1)}] {i}')
-    fileName = input(f'Which file to use for restored? (1-{len(possFiles)}) ')
-    if fileName=='':
-      fileName = '1'
-    fileName = possFiles[int(fileName)-1]
+    fileChoice = input(f'Which file to use for restored? (1-{len(possFiles)}) ')
+    if fileChoice=='':
+      fileChoice = '1'
+    fileName = possFiles[int(fileChoice)-1]
   # use information
   authUser = requests.auth.HTTPBasicAuth(userName, password)
   with ZipFile(fileName, 'r', compression=ZIP_DEFLATED) as zipFile:


### PR DESCRIPTION
Fix #232 
- Ignore configuration .pastaELN.json when restoring
- allow to enter "", when only one file is there for restoring