### PR TITLE
perf(dataverse): implement changes to improve multiple uploads

### DIFF
--- a/pasta_eln/GUI/dataverse/dialog_extension.py
+++ b/pasta_eln/GUI/dataverse/dialog_extension.py
@@ -1,4 +1,5 @@
 """ Represents QT dialog extension. """
+
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -27,7 +28,6 @@ class DialogExtension(QDialog):
       None
   """
   closed = QtCore.Signal()
-
 
   def closeEvent(self, close_event: QCloseEvent) -> None:
     """

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -75,6 +75,7 @@ class MainDialog(Ui_MainDialogBase):
     self.instance = DialogExtension()
     super().setupUi(self.instance)
     self.db_api = DatabaseAPI()
+    self.db_api.initialize_database()
     self.is_dataverse_configured: tuple[bool, str] = self.check_if_dataverse_is_configured()
     self.config_dialog: ConfigDialog | None = None
 
@@ -112,7 +113,9 @@ class MainDialog(Ui_MainDialogBase):
     Args:
         self: The instance of the class.
     """
-    for project in self.db_api.get_models(ProjectModel):
+    models = self.db_api.get_models(ProjectModel)
+    models = models * 30
+    for project in models:
       if isinstance(project, ProjectModel):
         widget = self.get_project_widget(project)
         self.projectsScrollAreaVerticalLayout.addWidget(widget)

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -113,9 +113,7 @@ class MainDialog(Ui_MainDialogBase):
     Args:
         self: The instance of the class.
     """
-    models = self.db_api.get_models(ProjectModel)
-    models = models * 30
-    for project in models:
+    for project in self.db_api.get_models(ProjectModel):
       if isinstance(project, ProjectModel):
         widget = self.get_project_widget(project)
         self.projectsScrollAreaVerticalLayout.addWidget(widget)
@@ -151,6 +149,7 @@ class MainDialog(Ui_MainDialogBase):
     """
     Creates the project widget.
 
+
     Explanation:
         This method retrieves the project widget for a specific project.
         It creates a QWidget instance and sets up the UI for the project widget.
@@ -174,6 +173,8 @@ class MainDialog(Ui_MainDialogBase):
     project_widget_ui.projectNameLabel.setToolTip(project.name)
     project_widget_ui.modifiedDateTimeLabel.setText(
       datetime.datetime.fromisoformat(project.date or "").strftime("%Y-%m-%d %H:%M:%S"))
+    project_widget_ui.projectDocIdLabel.hide()
+    project_widget_ui.projectDocIdLabel.setText(project.id)
     return project_widget_frame
 
   def start_upload(self) -> None:
@@ -196,8 +197,10 @@ class MainDialog(Ui_MainDialogBase):
           project_widget.findChild(QtWidgets.QLabel, name="projectNameLabel").toolTip())
         self.uploadQueueVerticalLayout.addWidget(upload_widget["base"])
         widget = upload_widget["widget"]
+        project_id = project_widget.findChild(QtWidgets.QLabel, name="projectDocIdLabel").text()
         task_thread = TaskThreadExtension(
           DataUploadTask(widget.uploadProjectLabel.text(),
+                         project_id,
                          widget.uploadProgressBar.setValue,
                          widget.statusLabel.setText,
                          widget.statusIconLabel.setPixmap,

--- a/pasta_eln/GUI/dataverse/project_item_frame_base.py
+++ b/pasta_eln/GUI/dataverse/project_item_frame_base.py
@@ -41,6 +41,10 @@ class Ui_ProjectItemFrame(object):
     self.modifiedDateTimeLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeading|QtCore.Qt.AlignmentFlag.AlignLeft|QtCore.Qt.AlignmentFlag.AlignVCenter)
     self.modifiedDateTimeLabel.setObjectName("modifiedDateTimeLabel")
     self.horizontalLayout.addWidget(self.modifiedDateTimeLabel)
+    self.projectDocIdLabel = QtWidgets.QLabel(parent=ProjectItemFrame)
+    self.projectDocIdLabel.setText("")
+    self.projectDocIdLabel.setObjectName("projectDocIdLabel")
+    self.horizontalLayout.addWidget(self.projectDocIdLabel)
     self.horizontalLayout_2.addLayout(self.horizontalLayout)
 
     self.retranslateUi(ProjectItemFrame)

--- a/pasta_eln/GUI/dataverse/project_item_frame_base.ui
+++ b/pasta_eln/GUI/dataverse/project_item_frame_base.ui
@@ -91,6 +91,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QLabel" name="projectDocIdLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/pasta_eln/GUI/dataverse/upload_config_dialog.py
+++ b/pasta_eln/GUI/dataverse/upload_config_dialog.py
@@ -59,6 +59,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     self.instance = QDialog()
     super().setupUi(self.instance)
     self.db_api = DatabaseAPI()
+    self.db_api.initialize_database()
     self.numParallelComboBox.addItems(map(str, range(2, 6)))
     self.numParallelComboBox.setCurrentIndex(2)
     self.instance.setWindowModality(QtCore.Qt.ApplicationModal)

--- a/pasta_eln/dataverse/data_upload_task.py
+++ b/pasta_eln/dataverse/data_upload_task.py
@@ -42,6 +42,7 @@ class DataUploadTask(GenericTaskObject):
 
   def __init__(self,
                project_name: str,
+               project_doc_id: str,
                progress_update_callback: Callable[[int], None],
                status_label_set_text_callback: Callable[[str], None],
                status_icon_set_pixmap_callback: Callable[[QPixmap | QImage | str], None],
@@ -68,6 +69,7 @@ class DataUploadTask(GenericTaskObject):
 
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
     self.project_name = project_name
+    self.project_doc_id = project_doc_id
 
     # Connect slots
     self.progress_changed.connect(progress_update_callback)
@@ -161,7 +163,8 @@ class DataUploadTask(GenericTaskObject):
     # Create upload model in database
     self.upload_model = UploadModel(project_name=self.project_name,
                                     status=UploadStatusValues.Queued.name,
-                                    log=f"Upload initiated for project {self.project_name} at {datetime.now().isoformat()}\n")
+                                    log=f"Upload initiated for project {self.project_name} at {datetime.now().isoformat()}\n",
+                                    project_doc_id=self.project_doc_id)
     self.upload_model = self.db_api.create_model_document(self.upload_model)  # type: ignore[assignment]
     self.logger.info("Upload model created: %s", self.upload_model)
     # Read config and get the login information along with the metadata

--- a/pasta_eln/dataverse/data_upload_task.py
+++ b/pasta_eln/dataverse/data_upload_task.py
@@ -78,6 +78,7 @@ class DataUploadTask(GenericTaskObject):
     # Create progress thread to update the progress
     self.progress_thread = ProgressUpdaterThread()
     self.progress_thread.progress_update = self.progress_changed
+    self.progress_thread.end.connect(self.progress_thread.deleteLater)
 
   def start_task(self) -> None:
     """
@@ -176,16 +177,16 @@ class DataUploadTask(GenericTaskObject):
 
   def finalize_upload_task(self, status: str = UploadStatusValues.Finished.name) -> None:
     """
-    Finalizes the upload task by emitting signals to cancel progress, mark as finished, and update the UI status.
+    Finalizes the upload task by emitting signals to cancel progress, mark as finish, and update the UI status.
 
     Args:
         status (str): The status to be emitted.
     """
     self.progress_thread.finalize.emit()
-    self.finished.emit()
     if self.upload_model:
       self.upload_model.finished_date_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     self.update_changed_status(status)
+    self.finish.emit()
 
   def create_dataset_for_pasta_project(self) -> str | None:
     """
@@ -302,7 +303,7 @@ class DataUploadTask(GenericTaskObject):
         It updates the upload model log and status accordingly, and emits the status_changed signal.
 
     """
-    if self.cancelled:
+    if self.cancelled or self.finished:
       return
     super().cancel_task()
     if self.upload_model:

--- a/pasta_eln/dataverse/data_upload_task.py
+++ b/pasta_eln/dataverse/data_upload_task.py
@@ -12,13 +12,14 @@ import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import Callable
+from typing import Any, Callable
 
 from PySide6 import QtCore
 from PySide6.QtGui import QImage, QPixmap
 
 from pasta_eln.dataverse.client import DataverseClient
 from pasta_eln.dataverse.config_error import ConfigError
+from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.database_api import DatabaseAPI
 from pasta_eln.dataverse.generic_task_object import GenericTaskObject
 from pasta_eln.dataverse.progress_updater_thread import ProgressUpdaterThread
@@ -56,27 +57,17 @@ class DataUploadTask(GenericTaskObject):
         upload_cancel_clicked_signal_callback (QtCore.Signal): Signal for upload cancellation.
     """
     super().__init__()
+    self.db_api: DatabaseAPI | None = None
+    self.dataverse_client: DataverseClient | None = None
+    self.upload_model: UploadModel | None = None
+    self.config_model: ConfigModel | None = None
+    self.dataverse_id: str = ""
+    self.dataverse_api_token: str = ""
+    self.dataverse_server_url: str = ""
+    self.metadata: dict[str, Any] = {}
+
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
     self.project_name = project_name
-    self.db_api = DatabaseAPI()
-
-    # Create upload model in database
-    self.upload_model = UploadModel(project_name=self.project_name,
-                                    status=UploadStatusValues.Queued.name,
-                                    log=f"Upload initiated for project {self.project_name} at {datetime.now().isoformat()}\n")
-    self.upload_model = self.db_api.create_model_document(self.upload_model)  # type: ignore[assignment]
-    self.logger.info("Upload model created: %s", self.upload_model)
-
-    # Read config and get the login information along with the metadata
-    self.config_model = self.db_api.get_config_model()
-    if self.config_model is None:
-      raise ConfigError("Config model not found/Invalid Login Information.")
-    login_info = self.config_model.dataverse_login_info or {}
-    self.dataverse_server_url: str = login_info.get("server_url", "")
-    self.dataverse_api_token: str = login_info.get("api_token", "")
-    self.dataverse_id: str = login_info.get("dataverse_id", "")
-    self.metadata = self.config_model.metadata or {}
-    self.dataverse_client = DataverseClient(self.dataverse_server_url, self.dataverse_api_token, 60)
 
     # Connect slots
     self.progress_changed.connect(progress_update_callback)
@@ -97,12 +88,14 @@ class DataUploadTask(GenericTaskObject):
         self: Instance of the data upload task.
     """
     super().start_task()
+    self.initialize()
 
     # Emitting signals to update initial status
     self.update_changed_status(UploadStatusValues.Uploading.name)
     # Emit the upload model id
     # so that the parent thread can retrieve the model
-    self.upload_model_created.emit(self.upload_model.id)
+    if self.upload_model:
+      self.upload_model_created.emit(self.upload_model.id)
 
     # Start the progress updater thread
     self.progress_thread.start()
@@ -149,8 +142,37 @@ class DataUploadTask(GenericTaskObject):
     self.update_log(
       f"Successfully uploaded ELN file, URL: {upload_url}",
       self.logger.info)
-    self.upload_model.dataverse_url = upload_url
+    if self.upload_model:
+      self.upload_model.dataverse_url = upload_url
     self.finalize_upload_task(UploadStatusValues.Cancelled.name if self.cancelled else UploadStatusValues.Finished.name)
+
+  def initialize(self) -> None:
+    """
+    Initialize the data upload task by setting up the database API,
+    creating an upload model, and reading configuration information.
+    Since this method consists of heavy operations, it's not invoked inside the constructor.
+
+    Raises:
+        ConfigError: If the config model is not found or contains invalid login information.
+    """
+
+    self.db_api = DatabaseAPI()
+    # Create upload model in database
+    self.upload_model = UploadModel(project_name=self.project_name,
+                                    status=UploadStatusValues.Queued.name,
+                                    log=f"Upload initiated for project {self.project_name} at {datetime.now().isoformat()}\n")
+    self.upload_model = self.db_api.create_model_document(self.upload_model)  # type: ignore[assignment]
+    self.logger.info("Upload model created: %s", self.upload_model)
+    # Read config and get the login information along with the metadata
+    self.config_model = self.db_api.get_config_model()
+    if self.config_model is None:
+      raise ConfigError("Config model not found/Invalid Login Information.")
+    login_info = self.config_model.dataverse_login_info or {}
+    self.dataverse_server_url = login_info.get("server_url", "")
+    self.dataverse_api_token = login_info.get("api_token", "")
+    self.dataverse_id = login_info.get("dataverse_id", "")
+    self.metadata = self.config_model.metadata or {}
+    self.dataverse_client = DataverseClient(self.dataverse_server_url, self.dataverse_api_token, 60)
 
   def finalize_upload_task(self, status: str = UploadStatusValues.Finished.name) -> None:
     """
@@ -161,7 +183,8 @@ class DataUploadTask(GenericTaskObject):
     """
     self.progress_thread.finalize.emit()
     self.finished.emit()
-    self.upload_model.finished_date_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    if self.upload_model:
+      self.upload_model.finished_date_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     self.update_changed_status(status)
 
   def create_dataset_for_pasta_project(self) -> str | None:
@@ -171,6 +194,8 @@ class DataUploadTask(GenericTaskObject):
     Returns:
         str or None: The persistent identifier of the created dataset if successful, None otherwise.
     """
+    if self.upload_model is None or self.dataverse_client is None:
+      return None
     self.update_log(f"Step 2: Creating dataset..... {self.upload_model.project_name}", self.logger.info)
     persistent_id = None
 
@@ -201,6 +226,8 @@ class DataUploadTask(GenericTaskObject):
     Returns:
         bool: True if the dataset is unlocked, False otherwise.
     """
+    if self.dataverse_client is None:
+      return False
     self.update_log("Step 3: Checking if dataset is unlocked after the publish operation..", self.logger.info)
     unlocked = False
     for _ in range(10):
@@ -235,6 +262,8 @@ class DataUploadTask(GenericTaskObject):
     """
     self.update_log(f"Step 4: Uploading file {eln_file_path} to dataset with PID: {persistent_id}.....",
                     self.logger.info)
+    if self.upload_model is None or self.dataverse_client is None:
+      return None
     result = asyncio.run(self.dataverse_client.upload_file(persistent_id,
                                                            eln_file_path,
                                                            f"Generated ELN file for the project: {self.upload_model.project_name}",
@@ -260,8 +289,9 @@ class DataUploadTask(GenericTaskObject):
     """
     if logger_method:
       logger_method(log)
-    self.upload_model.log = log
-    self.db_api.update_model_document(self.upload_model)
+    if self.upload_model and self.db_api:
+      self.upload_model.log = log
+      self.db_api.update_model_document(self.upload_model)
 
   def cancel_task(self) -> None:
     """
@@ -275,7 +305,8 @@ class DataUploadTask(GenericTaskObject):
     if self.cancelled:
       return
     super().cancel_task()
-    self.upload_model.log = f"Cancelled at {datetime.now().isoformat()}"
+    if self.upload_model:
+      self.upload_model.log = f"Cancelled at {datetime.now().isoformat()}"
     self.progress_thread.cancel.emit()
     self.update_changed_status(UploadStatusValues.Cancelled.name)
 
@@ -290,8 +321,9 @@ class DataUploadTask(GenericTaskObject):
     Args:
         status (str): The status value to update the upload task to. Defaults to 'Queued'.
     """
-    self.upload_model.status = status
-    self.db_api.update_model_document(self.upload_model)
+    if self.upload_model and self.db_api:
+      self.upload_model.status = status
+      self.db_api.update_model_document(self.upload_model)
     self.status_changed.emit(status)
 
   def check_if_cancelled(self) -> bool:

--- a/pasta_eln/dataverse/database_api.py
+++ b/pasta_eln/dataverse/database_api.py
@@ -55,7 +55,6 @@ class DatabaseAPI:
     self.data_hierarchy_doc_id = '-dataHierarchy-'
     self.upload_model_view_name = "dvUploadView"
     self.project_model_view_name = "dvProjectsView"
-    self.initialize_database()
     _, self.encrypt_key = get_encrypt_key(self.logger)
 
   def create_dataverse_design_document(self) -> Document:

--- a/pasta_eln/dataverse/database_api.py
+++ b/pasta_eln/dataverse/database_api.py
@@ -53,8 +53,8 @@ class DatabaseAPI:
     self.design_doc_name = '_design/viewDataverse'
     self.config_doc_id = '-dataverseConfig-'
     self.data_hierarchy_doc_id = '-dataHierarchy-'
-    self.upload_model_view_name = "dvUploadView"
-    self.project_model_view_name = "dvProjectsView"
+    self.upload_model_view_name = 'dvUploadView'
+    self.project_model_view_name = 'dvProjectsView'
     _, self.encrypt_key = get_encrypt_key(self.logger)
 
   def create_dataverse_design_document(self) -> Document:

--- a/pasta_eln/dataverse/generic_task_object.py
+++ b/pasta_eln/dataverse/generic_task_object.py
@@ -96,7 +96,7 @@ class GenericTaskObject(QObject):
     self.logger.info("Cleaning up task, id: %s", self.id)
     self.cleaned = True
 
-  def finish_task(self):
+  def finish_task(self) -> None:
     """
     Finish up the task.
 

--- a/pasta_eln/dataverse/generic_task_object.py
+++ b/pasta_eln/dataverse/generic_task_object.py
@@ -25,7 +25,7 @@ class GenericTaskObject(QObject):
   """
   cancel = QtCore.Signal()
   start = QtCore.Signal()
-  finished = QtCore.Signal()
+  finish = QtCore.Signal()
   id_iterator = itertools.count()
 
   def __init__(self) -> None:
@@ -48,7 +48,9 @@ class GenericTaskObject(QObject):
     self.cancelled = False
     self.started = False
     self.cleaned = False
+    self.finished = False
     self.cancel.connect(lambda: self.cancel_task())  # pylint: disable=unnecessary-lambda
+    self.finish.connect(lambda: self.finish_task())  # pylint: disable=unnecessary-lambda
     self.start.connect(self.start_task)
 
   def cancel_task(self) -> None:
@@ -93,3 +95,14 @@ class GenericTaskObject(QObject):
     """
     self.logger.info("Cleaning up task, id: %s", self.id)
     self.cleaned = True
+
+  def finish_task(self):
+    """
+    Finish up the task.
+
+    Args:
+        self: The instance of the class.
+    """
+
+    self.logger.info("Finishing up the task, id: %s", self.id)
+    self.finished = True

--- a/pasta_eln/dataverse/progress_updater_thread.py
+++ b/pasta_eln/dataverse/progress_updater_thread.py
@@ -25,13 +25,14 @@ class ProgressUpdaterThread(QThread):
   progress_update = QtCore.Signal(int)
   cancel = QtCore.Signal()
   finalize = QtCore.Signal()
+  end = QtCore.Signal()
 
   def __init__(self) -> None:
     """
-    Initializes the ProgressUpdaterThread instance with default values and connects the cancel signal.
+    Initialize the progress updater thread.
 
-    Explanation:
-        Sets the 'finished' attribute to False and connects the 'cancel' signal to the 'cancel_progress' method.
+    Args:
+        self: The instance of the progress updater thread.
     """
     super().__init__()
     self.cancelled = False
@@ -62,14 +63,14 @@ class ProgressUpdaterThread(QThread):
       time.sleep(1)
     if not self.cancelled:
       self.progress_update.emit(100)
-    self.exit()
+    self.end.emit()
 
   def cancel_progress(self) -> None:
     """
     Sets the flag to indicate that the progress should be cancelled.
 
     Explanation:
-        This method sets the 'finished' flag to True, indicating that the progress should be terminated.
+        This method sets the 'finish' flag to True, indicating that the progress should be terminated.
     """
     self.cancelled = True
 
@@ -81,3 +82,13 @@ class ProgressUpdaterThread(QThread):
         This function sets the 'finalized' attribute to True, indicating that the progress update is complete.
     """
     self.finalized = True
+
+  def cleanup(self) -> None:
+    """
+    Finalizes the progress update.
+
+    Explanation:
+        This function sets the 'finalized' attribute to True, indicating that the progress update is complete.
+    """
+    self.cancel.disconnect()
+    self.finalize.disconnect()

--- a/pasta_eln/dataverse/progress_updater_thread.py
+++ b/pasta_eln/dataverse/progress_updater_thread.py
@@ -82,13 +82,3 @@ class ProgressUpdaterThread(QThread):
         This function sets the 'finalized' attribute to True, indicating that the progress update is complete.
     """
     self.finalized = True
-
-  def cleanup(self) -> None:
-    """
-    Finalizes the progress update.
-
-    Explanation:
-        This function sets the 'finalized' attribute to True, indicating that the progress update is complete.
-    """
-    self.cancel.disconnect()
-    self.finalize.disconnect()

--- a/pasta_eln/dataverse/upload_queue_manager.py
+++ b/pasta_eln/dataverse/upload_queue_manager.py
@@ -197,4 +197,3 @@ class UploadQueueManager(GenericTaskObject):
     self.logger.info("Cancelling upload queue and the empty the upload queue..")
     for upload_task_thread in self.upload_queue:
       upload_task_thread.task.cancel.emit()
-    # self.empty_upload_queue()

--- a/pasta_eln/dataverse/upload_queue_manager.py
+++ b/pasta_eln/dataverse/upload_queue_manager.py
@@ -79,7 +79,7 @@ class UploadQueueManager(GenericTaskObject):
 
     Explanation:
         This method adds the given upload_task_thread to the upload queue.
-        It also connects the finished signal of the task to the remove_from_queue method.
+        It also connects the finish signal of the task to the remove_from_queue method.
 
     Args:
         upload_task_thread (TaskThreadExtension): The thread task to be added to the upload queue.
@@ -87,7 +87,8 @@ class UploadQueueManager(GenericTaskObject):
     """
     self.logger.info("Adding thread task to upload queue, id: %s", upload_task_thread.task.id)
     self.upload_queue.append(upload_task_thread)
-    upload_task_thread.task.finished.connect(lambda: self.remove_from_queue(upload_task_thread))
+    upload_task_thread.task.finish.connect(lambda: self.remove_from_queue(upload_task_thread))
+    upload_task_thread.task.cancel.connect(lambda: self.remove_from_queue(upload_task_thread))
 
   def remove_from_queue(self, upload_task_thread: TaskThreadExtension) -> None:
     """
@@ -128,7 +129,10 @@ class UploadQueueManager(GenericTaskObject):
         for upload_task_thread in self.upload_queue:
           if self.cancelled or len(self.running_queue) >= self.number_of_concurrent_uploads:
             break
-          if not upload_task_thread.task.started and not upload_task_thread.task.cancelled:
+          if (not upload_task_thread.task.started
+              and not upload_task_thread.task.cancelled
+              and not upload_task_thread.task.finished
+              and upload_task_thread not in self.running_queue):
             self.running_queue.append(upload_task_thread)
             upload_task_thread.task.start.emit()
       sleep(0.5)
@@ -162,7 +166,7 @@ class UploadQueueManager(GenericTaskObject):
     """
     self.logger.info("Emptying upload queue..")
     for upload_task_thread in self.upload_queue:
-      upload_task_thread.quit()
+      upload_task_thread.task.deleteLater()
     self.upload_queue.clear()
 
   def cancel_task(self) -> None:
@@ -193,4 +197,4 @@ class UploadQueueManager(GenericTaskObject):
     self.logger.info("Cancelling upload queue and the empty the upload queue..")
     for upload_task_thread in self.upload_queue:
       upload_task_thread.task.cancel.emit()
-    self.empty_upload_queue()
+    # self.empty_upload_queue()

--- a/tests/unit_tests/test_dataverse_data_upload_task.py
+++ b/tests/unit_tests/test_dataverse_data_upload_task.py
@@ -83,7 +83,7 @@ def setup_task(mocker, mock_db_api, mock_dataverse_client, mock_progress_thread,
   task.upload_model_created = mocker.MagicMock()
   task.cancel = mocker.MagicMock()
   task.start = mocker.MagicMock()
-  task.finished = mocker.MagicMock()
+  task.finish = mocker.MagicMock()
   task.id_iterator = mocker.MagicMock()
   return task
 
@@ -334,7 +334,7 @@ class TestDataverseDataUploadTask:
 
     # Assert
     setup_task.progress_thread.finalize.emit.assert_called_once()
-    setup_task.finished.emit.assert_called_once()
+    setup_task.finish.emit.assert_called_once()
     setup_task.status_changed.emit.assert_called_once_with(expected_status)
 
   # Parametrized test cases

--- a/tests/unit_tests/test_dataverse_data_upload_task.py
+++ b/tests/unit_tests/test_dataverse_data_upload_task.py
@@ -47,6 +47,7 @@ def mock_upload_model():
 def setup_task(mocker, mock_db_api, mock_dataverse_client, mock_progress_thread, mock_upload_model):
   # Arrange
   project_name = "Test Project"
+  project_id = "Test ID"
   mocker.patch('pasta_eln.dataverse.data_upload_task.logging.getLogger')
   mock_db_api.return_value.create_model_document.return_value = UploadModel(_id="1234567890abcdef1234567890abcdef",
                                                                             _rev="1-1234567890abcdef1234567890abcdef",
@@ -73,11 +74,15 @@ def setup_task(mocker, mock_db_api, mock_dataverse_client, mock_progress_thread,
   upload_cancel_clicked_signal_callback = MagicMock()
   task = DataUploadTask(
     project_name,
+    project_id,
     progress_update_callback,
     status_label_set_text_callback,
     status_icon_set_pixmap_callback,
     upload_cancel_clicked_signal_callback,
   )
+  task.db_api = mock_db_api
+  task.dataverse_client = mock_dataverse_client
+  task.upload_model = mock_upload_model
   task.progress_changed = mocker.MagicMock()
   task.status_changed = mocker.MagicMock()
   task.upload_model_created = mocker.MagicMock()
@@ -93,24 +98,23 @@ class TestDataverseDataUploadTask:
   def test_init_succeeds(self, mocker):
     # Arrange
     mock_get_logger = mocker.patch('pasta_eln.dataverse.data_upload_task.logging.getLogger')
-    db_api_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.DatabaseAPI')
-    client_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.DataverseClient')
     progress_thread_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.ProgressUpdaterThread')
-    upload_model_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.UploadModel')
     mocker.patch('pasta_eln.dataverse.data_upload_task.super')
-    datetime_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.datetime')
     DataUploadTask.progress_changed = mocker.MagicMock()
     DataUploadTask.status_changed = mocker.MagicMock()
+    DataUploadTask.end = mocker.MagicMock()
     DataUploadTask.upload_model_created = mocker.MagicMock()
     progress_update_callback = MagicMock()
     status_label_set_text_callback = MagicMock()
     status_icon_set_pixmap_callback = MagicMock()
     upload_cancel_clicked_signal_callback = MagicMock()
     project_name = "Test Project"
+    project_id = "Test ID"
 
     # Act
     task = DataUploadTask(
       project_name,
+      project_id,
       progress_update_callback,
       status_label_set_text_callback,
       status_icon_set_pixmap_callback,
@@ -120,46 +124,73 @@ class TestDataverseDataUploadTask:
     # Assert
     mock_get_logger.assert_called_once_with('pasta_eln.dataverse.data_upload_task.DataUploadTask')
     assert task.project_name == project_name, "Project name should be set"
-    assert task.db_api == db_api_mock.return_value, "Database API should be set"
-    upload_model_mock.assert_called_once_with(project_name=project_name,
-                                              status=UploadStatusValues.Queued.name,
-                                              log=f"Upload initiated for project {project_name} at {datetime_mock.now.return_value.isoformat.return_value}\n")
-    db_api_mock.return_value.create_model_document.assert_called_once_with(upload_model_mock.return_value)
-    assert task.upload_model == db_api_mock.return_value.create_model_document.return_value, "Upload model should be set"
-    mock_get_logger.return_value.info.assert_called_once_with("Upload model created: %s", task.upload_model)
-    db_api_mock.return_value.get_config_model.assert_called_once()
-    assert task.config_model == db_api_mock.return_value.get_config_model.return_value, "Config model should be set"
-    task.config_model.dataverse_login_info.get.assert_any_call("server_url", "")
-    assert task.dataverse_server_url == task.config_model.dataverse_login_info.get("server_url",
-                                                                                   ""), "Dataverse server URL should be set"
-    task.config_model.dataverse_login_info.get.assert_any_call("api_token", "")
-    assert task.dataverse_api_token == task.config_model.dataverse_login_info.get("api_token",
-                                                                                  ""), "Dataverse API Token should be set"
-    task.config_model.dataverse_login_info.get.assert_any_call("dataverse_id", "")
-    assert task.dataverse_id == task.config_model.dataverse_login_info.get("dataverse_id",
-                                                                           ""), "Dataverse ID should be set"
-    assert task.metadata == task.config_model.metadata, "Metadata should be set"
-    client_mock.assert_called_once_with(task.dataverse_server_url, task.dataverse_api_token, 60)
-    assert task.dataverse_client == client_mock.return_value, "Dataverse client should be set"
+    assert task.db_api is None, "Database API should be set None"
+    assert task.upload_model is None, "Upload model should be set None"
+    assert task.config_model is None, "Config model should be set None"
+    assert task.metadata == {}, "Metadata should be set None"
     task.progress_changed.connect.assert_called_once_with(progress_update_callback)
     task.status_changed.connect.assert_called_once()
     upload_cancel_clicked_signal_callback.connect.assert_called_once()
     assert task.progress_thread == progress_thread_mock.return_value, "Progress thread should be set"
     assert task.progress_thread.progress_update == task.progress_changed, "Progress thread update signal should be set"
+    task.progress_thread.end.connect.assert_called_once_with(task.progress_thread.deleteLater)
 
-  @pytest.mark.parametrize("test_id, config_model, expected_exception", [
-    ("config_error", None, ConfigError),
-  ])
-  def test_init_config_error(self, mock_db_api, test_id, config_model, expected_exception):
-    mock_db_api.return_value.get_config_model.return_value = config_model
+  @pytest.mark.parametrize("project_name, project_doc_id, dataverse_login_info, metadata, expected_log_contains", [
+    # Success path test cases
+    ("Project1", "doc123", {"server_url": "http://example.com", "api_token": "token123", "dataverse_id": "dv123"},
+     {"key": "value"}, "Upload initiated for project Project1"),
+  ], ids=["success-path"])
+  def test_initialize_success_path(self, mocker, setup_task, mock_upload_model, mock_db_api, project_name, project_doc_id,
+                                 dataverse_login_info, metadata, expected_log_contains):
+    # Arrange
+    setup_task.project_name = project_name
+    setup_task.project_doc_id = project_doc_id
+    datetime_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.datetime')
+    mock_db_api.get_config_model.return_value = ConfigModel(dataverse_login_info=dataverse_login_info,
+                                                            metadata=metadata)
+    # Act
+    setup_task.initialize()
 
-    # Act / Assert
-    with pytest.raises(expected_exception):
-      DataUploadTask("Test Project",
-                     MagicMock(),
-                     MagicMock(),
-                     MagicMock(),
-                     MagicMock())
+    # Assert
+    mock_db_api.assert_called_once()
+    mock_upload_model.assert_called_once_with(project_name=setup_task.project_name,
+                                              status=UploadStatusValues.Queued.name,
+                                              log=f"Upload initiated for project {setup_task.project_name} at {datetime_mock.now.return_value.isoformat()}\n",
+                                              project_doc_id=setup_task.project_doc_id)
+    mock_db_api.return_value.create_model_document.assert_called_once_with(mock_upload_model.return_value)
+    setup_task.upload_model = mock_db_api.return_value.create_model_document.return_value
+    setup_task.logger.info.assert_called_with("Upload model created: %s", setup_task.upload_model)
+    mock_db_api.return_value.get_config_model.assert_called_once()
+    assert setup_task.dataverse_server_url == "dataverse_url", "Dataverse server URL should be set"
+    assert setup_task.dataverse_api_token == "api_token", "Dataverse API token should be set"
+    assert setup_task.dataverse_id == "dataverse_id", "Dataverse ID should be set"
+    assert setup_task.metadata == {"key": "value"}, "Metadata should be set"
+    assert setup_task.dataverse_client == setup_task.dataverse_client, "Dataverse client should be set"
+
+  @pytest.mark.parametrize("config_model_return, expected_exception_message", [
+    # Error case: Config model not found
+    (None, "Config model not found/Invalid Login Information."),
+    # Add more error cases as needed
+  ], ids=["config-error"])
+  def test_initialize_error_cases(self, mocker, setup_task, mock_db_api, mock_upload_model,
+                                  config_model_return, expected_exception_message):
+    # Arrange
+    datetime_mock = mocker.patch('pasta_eln.dataverse.data_upload_task.datetime')
+    mock_db_api.return_value.get_config_model.return_value = config_model_return
+
+    # Act & Assert
+    with pytest.raises(ConfigError) as exc_info:
+      setup_task.initialize()
+    assert str(exc_info.value) == expected_exception_message
+    mock_db_api.assert_called_once()
+    mock_upload_model.assert_called_once_with(project_name=setup_task.project_name,
+                                              status=UploadStatusValues.Queued.name,
+                                              log=f"Upload initiated for project {setup_task.project_name} at {datetime_mock.now.return_value.isoformat()}\n",
+                                              project_doc_id=setup_task.project_doc_id)
+    mock_db_api.return_value.create_model_document.assert_called_once_with(mock_upload_model.return_value)
+    setup_task.upload_model = mock_db_api.return_value.create_model_document.return_value
+    setup_task.logger.info.assert_called_with("Upload model created: %s", setup_task.upload_model)
+    mock_db_api.return_value.get_config_model.assert_called_once()
 
   # Happy path tests with various realistic test values
   @pytest.mark.parametrize("project_name,eln_file_path,persistent_id,file_pid,cancelled", [
@@ -280,44 +311,52 @@ class TestDataverseDataUploadTask:
     else:
       setup_task.finalize_upload_task.assert_called_with(expected_final_status)
 
-  @pytest.mark.parametrize("persistent_id, eln_file_path, upload_result, expected", [
+  @pytest.mark.parametrize("persistent_id, eln_file_path, upload_result, expected, test_id", [
     # Success path tests
     ("doi:10.1234/FK2", "/path/to/file1.txt",
      {"file_upload_result": "success",
       "dataset_publish_result": {"protocol": "doi", "authority": "10.1234", "identifier": "FK2"}},
-     "doi:10.1234/FK2"),
+     "doi:10.1234/FK2", "success-path-1"),
     ("doi:10.5678/FK3", "/path/to/file2.txt",
      {"file_upload_result": "success",
       "dataset_publish_result": {"protocol": "doi", "authority": "10.5678", "identifier": "FK3"}},
-     "doi:10.5678/FK3"),
+     "doi:10.5678/FK3", "success-path-2"),
     # Edge case: Empty file path
     ("doi:10.1234/FK2", "",
      {"file_upload_result": "success",
       "dataset_publish_result": {"protocol": "doi", "authority": "10.1234", "identifier": "FK2"}},
-     "doi:10.1234/FK2"),
+     "doi:10.1234/FK2", "edge-case-empty-file-path"),
+    ("", "", {}, "", "edge-case-null-dv-client"),
+    ("", "", {}, "", "edge-case-null-upload-model"),
     # Error cases
-    ("doi:10.1234/FK2", "/path/to/file3.txt", {"error": "File not found"}, None),
-    ("", "/path/to/file4.txt", {"error": "Invalid persistent ID"}, None),
-  ], ids=["success-path-1", "success-path-2", "edge-case-empty-file-path", "error-file-not-found",
-          "error-invalid-persistent-id"])
+    ("doi:10.1234/FK2", "/path/to/file3.txt", {"error": "File not found"}, None, "error-file-not-found"),
+    ("", "/path/to/file4.txt", {"error": "Invalid persistent ID"}, None, "error-invalid-persistent-id"),
+  ])
   def test_upload_generated_eln_file_to_dataset(self, mocker, setup_task, persistent_id, eln_file_path, upload_result,
-                                                expected):
+                                                expected, test_id):
     # Arrange
     mocker.patch('pasta_eln.dataverse.data_upload_task.DataUploadTask.update_log')
     mocker.patch("pasta_eln.dataverse.data_upload_task.asyncio.run", return_value=upload_result)
     setup_task.upload_model.project_name = "Test Project"
+    if test_id == "edge-case-null-dv-client":
+      setup_task.dataverse_client = None
+    if test_id == "edge-case-null-upload-model":
+      setup_task.upload_model = None
 
     # Act
     result = setup_task.upload_generated_eln_file_to_dataset(persistent_id, eln_file_path)
 
     # Assert
-    assert result == expected
-    if expected:
-      setup_task.update_log.assert_called_with(f'ELN File uploaded successfully, generated file PID: {expected}',
-                                               setup_task.logger.info)
+    if test_id == "edge-case-null-dv-client" or test_id == "edge-case-null-upload-model":
+      assert result is None
     else:
-      setup_task.update_log.assert_called_with(f'ELN File upload failed with errors: {upload_result}',
-                                               setup_task.logger.error)
+      assert result == expected
+      if expected:
+        setup_task.update_log.assert_called_with(f'ELN File uploaded successfully, generated file PID: {expected}',
+                                                 setup_task.logger.info)
+      else:
+        setup_task.update_log.assert_called_with(f'ELN File upload failed with errors: {upload_result}',
+                                                 setup_task.logger.error)
 
   @pytest.mark.parametrize("status, expected_status", [
     pytest.param(UploadStatusValues.Finished.name, UploadStatusValues.Finished.name, id="success_path_finished"),
@@ -347,6 +386,10 @@ class TestDataverseDataUploadTask:
     # Edge cases
     ({}, "Empty Metadata Project", "dv789", {"identifier": "789", "authority": "30.5072", "protocol": "doi"},
      "doi:30.5072/789", "Dataset creation succeeded with PID: doi:30.5072/789", "edge_case_empty_metadata"),
+    ({}, None, "dv789", {"identifier": "789", "authority": "30.5072", "protocol": "doi"},
+     "doi:30.5072/789", "Dataset creation succeeded with PID: doi:30.5072/789", "edge_case_null_update_model"),
+    ({}, "Project Name", "dv789", None,
+     "doi:30.5072/789", "Dataset creation succeeded with PID: doi:30.5072/789", "edge_case_null_dv_client"),
     # Error cases
     ({"key": "value"}, "Error Project", "dv000", "Error: Missing fields", None,
      "Dataset creation failed with errors: Error: Missing fields", "error_case_missing_fields"),
@@ -358,23 +401,29 @@ class TestDataverseDataUploadTask:
     mocker.patch('pasta_eln.dataverse.data_upload_task.get_flattened_metadata', return_value=metadata)
     mock_run = mocker.patch('pasta_eln.dataverse.data_upload_task.asyncio.run', return_value=result)
     setup_task.metadata = metadata
-    setup_task.upload_model = MagicMock(project_name=project_name)
+    setup_task.upload_model = MagicMock(project_name=project_name) if project_name else None
     setup_task.dataverse_id = dataverse_id
-    setup_task.dataverse_client.create_and_publish_dataset.return_value = result
+    if result:
+      setup_task.dataverse_client.create_and_publish_dataset.return_value = result
+    else:
+      setup_task.dataverse_client = None
 
     # Act
     persistent_id = setup_task.create_dataset_for_pasta_project()
 
     # Assert
-    setup_task.dataverse_client.create_and_publish_dataset.assert_called_once_with(dataverse_id,
-                                                                                   {"title": project_name, **metadata})
-    mock_run.assert_called_once_with(setup_task.dataverse_client.create_and_publish_dataset.return_value)
-    if expected_pid:
-      setup_task.update_log.assert_called_with(log_message, setup_task.logger.info)
-      assert persistent_id == expected_pid
+    if test_id == "edge_case_null_update_model" or test_id == "edge_case_null_dv_client":
+      assert persistent_id is None, "Expected None, got: {}".format(persistent_id)
     else:
-      setup_task.update_log.assert_called_with(log_message, setup_task.logger.error)
-      assert persistent_id is None
+      setup_task.dataverse_client.create_and_publish_dataset.assert_called_once_with(dataverse_id,
+                                                                                     {"title": project_name, **metadata})
+      mock_run.assert_called_once_with(setup_task.dataverse_client.create_and_publish_dataset.return_value)
+      if expected_pid:
+        setup_task.update_log.assert_called_with(log_message, setup_task.logger.info)
+        assert persistent_id == expected_pid
+      else:
+        setup_task.update_log.assert_called_with(log_message, setup_task.logger.error)
+        assert persistent_id is None
 
   @pytest.mark.parametrize("log, logger_method, expected_log, test_id", [
     # Happy path tests
@@ -472,6 +521,7 @@ class TestDataverseDataUploadTask:
        ], 2),
       # Edge case tests
       ("TestEdgeCase_EmptyDict", {}, True, ["Dataset with PID: test_pid is unlocked already!"], 0),
+      ("TestEdgeCase_NullDvClient", {}, False, None, 0),
       # Error case tests
       ("TestErrorCase_NonDictResponse", "Error response", False,
        ["Dataset lock check failed. Error response", "Dataset with PID: test_pid is still locked after 10 retries!"],
@@ -488,26 +538,31 @@ class TestDataverseDataUploadTask:
                                                  list) else get_dataset_locks_return_value)
     mock_sleep = mocker.patch('pasta_eln.dataverse.data_upload_task.time.sleep')
     mocker.patch('pasta_eln.dataverse.data_upload_task.DataUploadTask.update_log')
-
-    # Simulate different responses for consecutive calls
-    if isinstance(get_dataset_locks_return_value, list):
-      setup_task.dataverse_client.get_dataset_locks.side_effect = get_dataset_locks_return_value
+    if test_id == "TestEdgeCase_NullDvClient":
+      setup_task.dataverse_client = None
     else:
-      setup_task.dataverse_client.get_dataset_locks.return_value = get_dataset_locks_return_value
+      # Simulate different responses for consecutive calls
+      if isinstance(get_dataset_locks_return_value, list):
+        setup_task.dataverse_client.get_dataset_locks.side_effect = get_dataset_locks_return_value
+      else:
+        setup_task.dataverse_client.get_dataset_locks.return_value = get_dataset_locks_return_value
 
     # Act
     result = setup_task.check_if_dataset_is_unlocked(persistent_id)
 
     # Assert
-    if sleep_call_count:
-      mock_sleep.assert_has_calls([mocker.call(1)] * sleep_call_count)
+    if test_id == "TestEdgeCase_NullDvClient":
+      assert result is False, f"Expected 'False' but got '{result}'"
     else:
-      mock_sleep.assert_not_called()
+      if sleep_call_count:
+        mock_sleep.assert_has_calls([mocker.call(1)] * sleep_call_count)
+      else:
+        mock_sleep.assert_not_called()
 
-    assert result == expected_result
-    for message in expected_log_messages:
-      setup_task.update_log.assert_any_call(message,
-                                            setup_task.logger.error if "locked after 10 retries!" in message else setup_task.logger.info)
+      assert result == expected_result
+      for message in expected_log_messages:
+        setup_task.update_log.assert_any_call(message,
+                                              setup_task.logger.error if "locked after 10 retries!" in message else setup_task.logger.info)
 
   @pytest.mark.parametrize("cancelled, expected_call, expected_log_message, expected_final_status", [
     (True, True, "User cancelled the upload, hence finalizing the upload!", UploadStatusValues.Cancelled.name),

--- a/tests/unit_tests/test_dataverse_database_api.py
+++ b/tests/unit_tests/test_dataverse_database_api.py
@@ -62,7 +62,6 @@ class TestDataverseDatabaseAPI:
     if test_id == "success_case_default_values":
       base_db_api_constructor_mock = mocker.patch('pasta_eln.dataverse.database_api.BaseDatabaseAPI',
                                                   return_value=base_db_api_mock)
-      initialize_database_mock = mocker.patch('pasta_eln.dataverse.database_api.DatabaseAPI.initialize_database')
     else:
       base_db_api_constructor_mock = mocker.patch('pasta_eln.dataverse.database_api.BaseDatabaseAPI',
                                                   side_effect=DatabaseError("test_error"))
@@ -81,7 +80,6 @@ class TestDataverseDatabaseAPI:
     if test_id == "success_case_default_values":
       assert db_api.db_api == base_db_api_mock
       assert db_api.design_doc_name == '_design/viewDataverse'
-      initialize_database_mock.assert_called_once()
     else:
       assert db_api is None
 

--- a/tests/unit_tests/test_dataverse_dialog_extension.py
+++ b/tests/unit_tests/test_dataverse_dialog_extension.py
@@ -1,0 +1,51 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_dialog_extension.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import pytest
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtWidgets import QApplication
+
+from pasta_eln.GUI.dataverse.dialog_extension import DialogExtension
+
+
+@pytest.fixture(scope="session")
+def qapp():
+  return QApplication([])
+
+
+@pytest.mark.skip(
+  reason="Disabled until the issue with instantiating DialogExtension is resolved")
+class TestDataverseDialogExtension(object):
+  @pytest.mark.parametrize("test_id", [
+    ("happy_path"),
+    ("edge_case_no_event_data"),  # Simulating an edge case if possible
+    # Error cases are not directly applicable here since the method and class are straightforward
+  ])
+  def test_closeEvent_emits_closed_signal(self, qapp, mocker, test_id):
+    # Arrange
+    mocker.patch("PySide6.QtWidgets.QDialog")
+    dialog = DialogExtension()
+    closed_emitted = False
+
+    def on_closed():
+      nonlocal closed_emitted
+      closed_emitted = True
+
+    dialog.closed.connect(on_closed)
+
+    if test_id == "happy_path":
+      close_event = QCloseEvent()
+    elif test_id == "edge_case_no_event_data":
+      # This is a hypothetical edge case; in reality, QCloseEvent doesn't require additional data
+      close_event = QCloseEvent()
+
+    # Act
+    dialog.closeEvent(close_event)
+
+    # Assert
+    assert closed_emitted, f"Closed signal was not emitted for {test_id}"

--- a/tests/unit_tests/test_dataverse_generic_task_object.py
+++ b/tests/unit_tests/test_dataverse_generic_task_object.py
@@ -116,3 +116,27 @@ class TestDataverseGenericTaskObject:
     # Assert
     assert task.cleaned == expected_cleaned
     mock_logger.info.assert_called_once_with('Cleaning up task, id: %s', 'test_id')
+
+  @pytest.mark.parametrize("test_id, initial_finished, expected_finished", [# Success path tests
+    ("success_case_1", False, True),  # Cleaning up task from non-cleaned state
+
+    # Edge case tests
+    ("edge_case_1", True, True),  # Cleaning up task when it's already cleaned
+
+    # Error case tests
+    # No error cases identified for cleanup as it does not raise exceptions or handle erroneous input
+  ])
+  def test_finish_task(self, mocker, test_id, initial_finished, expected_finished):
+    # Arrange
+    mocker.patch('pasta_eln.dataverse.generic_task_object.next', return_value="test_id")
+    mock_logger = mocker.MagicMock(spec=Logger)
+    mocker.patch('pasta_eln.dataverse.task_thread_extension.logging.getLogger', return_value=mock_logger)
+    task = GenericTaskObject()
+    task.finished = initial_finished
+
+    # Act
+    task.finish_task()
+
+    # Assert
+    assert task.finished == expected_finished
+    mock_logger.info.assert_called_once_with("Finishing up the task, id: %s", "test_id")

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -296,6 +296,7 @@ class TestDataverseMainDialog(object):
         mock_main_dialog.projectsScrollAreaVerticalLayout.itemAt.return_value.widget.assert_called_once()
         mock_project_widget.findChild.assert_any_call(QCheckBox, name="projectCheckBox")
         mock_project_widget.findChild.assert_any_call(QLabel, name="projectNameLabel")
+        mock_project_widget.findChild.assert_any_call(QLabel, name="projectDocIdLabel")
         mock_project_widget.findChild.return_value.isChecked.assert_called_once()
         mock_project_widget.findChild.return_value.toolTip.assert_called_once()
         mock_main_dialog.get_upload_widget.assert_called_once_with(
@@ -304,6 +305,7 @@ class TestDataverseMainDialog(object):
           mock_main_dialog.get_upload_widget.return_value["base"])
         mock_data_upload_task.assert_called_once_with(
           mock_main_dialog.get_upload_widget.return_value["widget"].uploadProjectLabel.text(),
+          mock_project_widget.findChild.return_value.text(),
           mock_main_dialog.get_upload_widget.return_value["widget"].uploadProgressBar.setValue,
           mock_main_dialog.get_upload_widget.return_value["widget"].statusLabel.setText,
           mock_main_dialog.get_upload_widget.return_value["widget"].statusIconLabel.setPixmap,

--- a/tests/unit_tests/test_dataverse_progress_updater_thread.py
+++ b/tests/unit_tests/test_dataverse_progress_updater_thread.py
@@ -53,7 +53,7 @@ class TestDataverseProgressUpdaterThread:
     mock_randint.side_effect = randint_values
     progress_updater = ProgressUpdaterThread()
     progress_updater.progress_update = mocker.MagicMock()
-    progress_updater.exit = mocker.MagicMock()
+    progress_updater.end = mocker.MagicMock()
     if cancelled_at is not None:
       progress_updater.cancelled = False
 
@@ -68,7 +68,7 @@ class TestDataverseProgressUpdaterThread:
     # Assert
     progress_call_list = [mocker.call(progress) for progress in expected_progress]
     progress_updater.progress_update.emit.assert_has_calls(progress_call_list)
-    progress_updater.exit.assert_called_once()
+    progress_updater.end.emit.assert_called_once()
 
   @pytest.mark.parametrize("initial_state, expected_state", [
     (False, True),  # ID: 01 - Test transitioning from False to True

--- a/tests/unit_tests/test_dataverse_upload_queue_manager.py
+++ b/tests/unit_tests/test_dataverse_upload_queue_manager.py
@@ -71,7 +71,7 @@ class TestDataverseUploadQueueManager:
     # Assert
     assert mock_manager.upload_queue == task_threads
     for task_thread in task_threads:
-      task_thread.task.finished.connect.assert_called_once()
+      task_thread.task.finish.connect.assert_called_once()
 
   # Edge cases tests
   @pytest.mark.parametrize("test_id, concurrent_uploads, tasks_to_add, tasks_to_remove, expected_upload_queue_length",


### PR DESCRIPTION
- Moved all time consuming heavy invocations to the thread run method, so that the main GUI thread  is not blocked.
- Refactored the progress thread updater to release the resources upon update completion.
- Updated the tests as per the changes