### PR TITLE
fix(dataverse): implement fix for the cancellation logic issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Developers: Windows
 
-### How to start Pasta ELN
+### How to start Pasta ELN~~~~
 - Anaconda
   - python -m pasta_eln.gui
   - DOES NOT WORK "pastaELN"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Developers: Windows
 
-### How to start Pasta ELN~~~~
+### How to start Pasta ELN
 - Anaconda
   - python -m pasta_eln.gui
   - DOES NOT WORK "pastaELN"

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -80,10 +80,10 @@ class MainDialog(Ui_MainDialogBase):
     self.config_dialog: ConfigDialog | None = None
 
     if self.is_dataverse_configured[0]:
-      self.config_upload_dialog = UploadConfigDialog()
       self.completed_uploads_dialog = CompletedUploads()
       self.edit_metadata_dialog = EditMetadataDialog()
       self.upload_manager_task = UploadQueueManager()
+      self.config_upload_dialog = UploadConfigDialog(self.upload_manager_task.set_concurrent_uploads)
       self.upload_manager_task_thread = TaskThreadExtension(self.upload_manager_task)
 
       # Connect signals and slots
@@ -94,7 +94,6 @@ class MainDialog(Ui_MainDialogBase):
       self.configureUploadPushButton.clicked.connect(self.show_configure_upload)
       self.showCompletedPushButton.clicked.connect(self.show_completed_uploads)
       self.editFullMetadataPushButton.clicked.connect(self.show_edit_metadata)
-      self.config_upload_dialog.config_reloaded.connect(self.upload_manager_task.set_concurrent_uploads)
       self.cancelAllPushButton.clicked.connect(self.upload_manager_task.cancel_all_tasks.emit)
       self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel).clicked.connect(self.close_ui)
       self.instance.closed.connect(self.close_ui)

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -222,13 +222,13 @@ class MainDialog(Ui_MainDialogBase):
     """
     for widget_pos in reversed(range(self.uploadQueueVerticalLayout.count())):
       project_widget = self.uploadQueueVerticalLayout.itemAt(widget_pos).widget()
-      progress_value = project_widget.findChild(QtWidgets.QProgressBar, name="uploadProgressBar").value()
       status_text = project_widget.findChild(QtWidgets.QLabel, name="statusLabel").text()
-      if (progress_value == 100 and status_text in [
+      if (status_text in [
         UploadStatusValues.Finished.name,
         UploadStatusValues.Error.name,
-        UploadStatusValues.Warning.name
-      ]) or status_text == UploadStatusValues.Cancelled.name:
+        UploadStatusValues.Warning.name,
+        UploadStatusValues.Cancelled.name
+      ]):
         project_widget.setParent(None)
 
   def select_deselect_all_projects(self, checked: bool) -> None:

--- a/pasta_eln/GUI/dataverse/upload_config_dialog.py
+++ b/pasta_eln/GUI/dataverse/upload_config_dialog.py
@@ -8,7 +8,7 @@
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtCore import QObject
@@ -28,7 +28,6 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       It provides methods to load and save the configuration settings.
 
   """
-  config_reloaded = QtCore.Signal()
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -46,7 +45,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     """
     return super(UploadConfigDialog, cls).__new__(cls)
 
-  def __init__(self) -> None:
+  def __init__(self, config_reloaded_callback: Callable[[], None]) -> None:
     """
     Initializes the UploadConfigDialog.
 
@@ -69,6 +68,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     (self.numParallelComboBox.currentTextChanged[str]
      .connect(lambda num: setattr(self.config_model, "parallel_uploads_count", int(num))))
     self.set_data_hierarchy_types()
+    self.config_reloaded_callback = config_reloaded_callback
     self.load_ui()
 
   def load_ui(self) -> None:
@@ -149,7 +149,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       self.logger.error("Failed to load config model!")
       return
     self.db_api.save_config_model(self.config_model)
-    self.config_reloaded.emit()
+    self.config_reloaded_callback()
 
   def show(self) -> None:
     """
@@ -162,12 +162,3 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
         self: The instance of the class.
     """
     self.instance.show()
-
-
-if __name__ == "__main__":
-  import sys
-
-  app = QtWidgets.QApplication(sys.argv)
-  ui = UploadConfigDialog()
-  ui.instance.show()
-  sys.exit(app.exec())

--- a/pasta_eln/dataverse/data_upload_task.py
+++ b/pasta_eln/dataverse/data_upload_task.py
@@ -80,7 +80,7 @@ class DataUploadTask(GenericTaskObject):
     # Create progress thread to update the progress
     self.progress_thread = ProgressUpdaterThread()
     self.progress_thread.progress_update = self.progress_changed
-    self.progress_thread.end.connect(self.progress_thread.deleteLater)
+    self.progress_thread.end.connect(self.progress_thread.quit)
 
   def start_task(self) -> None:
     """

--- a/pasta_eln/dataverse/generic_task_object.py
+++ b/pasta_eln/dataverse/generic_task_object.py
@@ -95,6 +95,9 @@ class GenericTaskObject(QObject):
     """
     self.logger.info("Cleaning up task, id: %s", self.id)
     self.cleaned = True
+    self.cancel.disconnect()
+    self.finish.disconnect()
+    self.start.disconnect()
 
   def finish_task(self) -> None:
     """

--- a/pasta_eln/dataverse/upload_queue_manager.py
+++ b/pasta_eln/dataverse/upload_queue_manager.py
@@ -11,6 +11,7 @@ import logging
 from time import sleep
 
 from PySide6 import QtCore
+from PySide6.QtCore import QTimer
 
 from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.database_api import DatabaseAPI
@@ -88,7 +89,6 @@ class UploadQueueManager(GenericTaskObject):
     self.logger.info("Adding thread task to upload queue, id: %s", upload_task_thread.task.id)
     self.upload_queue.append(upload_task_thread)
     upload_task_thread.task.finish.connect(lambda: self.remove_from_queue(upload_task_thread))
-    upload_task_thread.task.cancel.connect(lambda: self.remove_from_queue(upload_task_thread))
 
   def remove_from_queue(self, upload_task_thread: TaskThreadExtension) -> None:
     """
@@ -108,6 +108,7 @@ class UploadQueueManager(GenericTaskObject):
     if upload_task_thread in self.running_queue:
       self.running_queue.remove(upload_task_thread)
     upload_task_thread.worker_thread.quit()
+    upload_task_thread.task.cleanup()
 
   def start_task(self) -> None:
     """
@@ -159,15 +160,28 @@ class UploadQueueManager(GenericTaskObject):
 
     Explanation:
         This method empties the upload queue by quitting each upload task thread and clearing the upload queue.
-
-    Args:
-        None
-
     """
     self.logger.info("Emptying upload queue..")
     for upload_task_thread in self.upload_queue:
-      upload_task_thread.task.deleteLater()
+      upload_task_thread.worker_thread.quit()
     self.upload_queue.clear()
+
+  def remove_cancelled_tasks(self) -> None:
+    """
+    Removes cancelled tasks from the upload queue.
+
+    Explanation:
+        This method identifies tasks in the upload queue that have been cancelled and removes them from the queue.
+        It also logs the removal of each cancelled task.
+
+    Args:
+        self: The instance of the UploadQueueManager.
+    """
+    self.logger.info("Removing cancelled tasks from the queue..")
+    cancelled_tasks = [upload_task_thread for upload_task_thread in self.upload_queue if
+                       upload_task_thread.task.cancelled]
+    for upload_task_thread in cancelled_tasks:
+      self.remove_from_queue(upload_task_thread)
 
   def cancel_task(self) -> None:
     """
@@ -193,7 +207,8 @@ class UploadQueueManager(GenericTaskObject):
     Args:
         self: The instance of the class.
     """
-
     self.logger.info("Cancelling upload queue and the empty the upload queue..")
     for upload_task_thread in self.upload_queue:
       upload_task_thread.task.cancel.emit()
+    if self.upload_queue:
+      QTimer.singleShot(500, lambda: self.remove_cancelled_tasks())  # pylint: disable=unnecessary-lambda

--- a/tests/component_tests/test_dataverse_upload_config_dialog.py
+++ b/tests/component_tests/test_dataverse_upload_config_dialog.py
@@ -50,7 +50,8 @@ def mock_database_api(mocker):
 def upload_config_dialog(qtbot, mocker, mock_database_api):
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.DatabaseAPI', return_value=mock_database_api)
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.logging')
-  dialog = UploadConfigDialog()
+  callback = mocker.MagicMock()
+  dialog = UploadConfigDialog(callback)
   mocker.resetall()
   qtbot.addWidget(dialog.instance)
   return dialog

--- a/tests/unit_tests/test_dataverse_data_upload_task.py
+++ b/tests/unit_tests/test_dataverse_data_upload_task.py
@@ -133,15 +133,16 @@ class TestDataverseDataUploadTask:
     upload_cancel_clicked_signal_callback.connect.assert_called_once()
     assert task.progress_thread == progress_thread_mock.return_value, "Progress thread should be set"
     assert task.progress_thread.progress_update == task.progress_changed, "Progress thread update signal should be set"
-    task.progress_thread.end.connect.assert_called_once_with(task.progress_thread.deleteLater)
+    task.progress_thread.end.connect.assert_called_once_with(task.progress_thread.quit)
 
   @pytest.mark.parametrize("project_name, project_doc_id, dataverse_login_info, metadata, expected_log_contains", [
     # Success path test cases
     ("Project1", "doc123", {"server_url": "http://example.com", "api_token": "token123", "dataverse_id": "dv123"},
      {"key": "value"}, "Upload initiated for project Project1"),
   ], ids=["success-path"])
-  def test_initialize_success_path(self, mocker, setup_task, mock_upload_model, mock_db_api, project_name, project_doc_id,
-                                 dataverse_login_info, metadata, expected_log_contains):
+  def test_initialize_success_path(self, mocker, setup_task, mock_upload_model, mock_db_api, project_name,
+                                   project_doc_id,
+                                   dataverse_login_info, metadata, expected_log_contains):
     # Arrange
     setup_task.project_name = project_name
     setup_task.project_doc_id = project_doc_id
@@ -416,7 +417,8 @@ class TestDataverseDataUploadTask:
       assert persistent_id is None, "Expected None, got: {}".format(persistent_id)
     else:
       setup_task.dataverse_client.create_and_publish_dataset.assert_called_once_with(dataverse_id,
-                                                                                     {"title": project_name, **metadata})
+                                                                                     {"title": project_name,
+                                                                                      **metadata})
       mock_run.assert_called_once_with(setup_task.dataverse_client.create_and_publish_dataset.return_value)
       if expected_pid:
         setup_task.update_log.assert_called_with(log_message, setup_task.logger.info)

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -330,10 +330,8 @@ class TestDataverseMainDialog(object):
     pytest.param(0, UploadStatusValues.Cancelled.name, True, id="SuccessPath-3-cancelled-with-0-progress"),
     # ID: SuccessPath-4
     pytest.param(100, UploadStatusValues.Cancelled.name, True, id="SuccessPath-4-cancelled-with-100-progress"),
-    # ID: EdgeCase-1 (Progress not 100)
-    pytest.param(99, UploadStatusValues.Finished.name, False, id="EdgeCase-1"),
-    # ID: EdgeCase-2 (Status not in specified list)
-    pytest.param(100, "InProgress", False, id="EdgeCase-2"),
+    # ID: EdgeCase-1 (Status not in a specified list)
+    pytest.param(100, "InProgress", False, id="EdgeCase-1"),
     # ID: ErrorCase-1 (Invalid status value)
     pytest.param(100, "InvalidStatus", False, id="ErrorCase-1"),
   ])
@@ -341,11 +339,9 @@ class TestDataverseMainDialog(object):
     # Arrange
     mock_main_dialog.uploadQueueVerticalLayout = MagicMock()
     widget = MagicMock()
-    progress_bar = mocker.MagicMock()
-    progress_bar.value.return_value = progress_value
     status_label = mocker.MagicMock()
     status_label.text.return_value = status_text
-    widget.findChild.side_effect = lambda x, name: progress_bar if x == QtWidgets.QProgressBar else status_label
+    widget.findChild.side_effect = lambda x, name: status_label
     mock_main_dialog.uploadQueueVerticalLayout.count.return_value = 1
     mock_main_dialog.uploadQueueVerticalLayout.itemAt.return_value = MagicMock(widget=MagicMock(return_value=widget))
 
@@ -357,9 +353,7 @@ class TestDataverseMainDialog(object):
     if expected_removal:
       mock_main_dialog.uploadQueueVerticalLayout.itemAt.assert_called_once_with(0)
       mock_main_dialog.uploadQueueVerticalLayout.itemAt.return_value.widget.assert_called_once()
-      widget.findChild.assert_any_call(QtWidgets.QProgressBar, name="uploadProgressBar")
       widget.findChild.assert_any_call(QtWidgets.QLabel, name="statusLabel")
-      progress_bar.value.assert_called_once()
       status_label.text.assert_called_once()
       widget.setParent.assert_called_once_with(None)
     else:

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -116,8 +116,6 @@ class TestDataverseMainDialog(object):
       dialog.configureUploadPushButton.clicked.connect.assert_called_once_with(dialog.show_configure_upload)
       dialog.showCompletedPushButton.clicked.connect.assert_called_once_with(dialog.show_completed_uploads)
       dialog.editFullMetadataPushButton.clicked.connect.assert_called_once_with(dialog.show_edit_metadata)
-      dialog.config_upload_dialog.config_reloaded.connect.assert_called_once_with(
-        dialog.upload_manager_task.set_concurrent_uploads)
       dialog.cancelAllPushButton.clicked.connect.assert_called_once_with(
         dialog.upload_manager_task.cancel_all_tasks.emit)
       dialog.buttonBox.button.assert_called_once_with(QtWidgets.QDialogButtonBox.Cancel)
@@ -138,7 +136,6 @@ class TestDataverseMainDialog(object):
       dialog.configureUploadPushButton.clicked.connect.assert_not_called()
       dialog.showCompletedPushButton.clicked.connect.assert_not_called()
       dialog.editFullMetadataPushButton.clicked.connect.assert_not_called()
-      dialog.config_upload_dialog.config_reloaded.connect.assert_not_called()
       dialog.cancelAllPushButton.clicked.connect.assert_not_called()
       dialog.buttonBox.button.assert_not_called()
       dialog.buttonBox.button.return_value.clicked.connect.assert_not_called()


### PR DESCRIPTION
- Corrected the cancellation logic for multiple projects upload.
- Corrected the config reload issue by introducing a callback instead of signal-slot mechanism.
- Corrected the tests accordingly.