### PR TITLE
feat(dataverse): integrate actual ELN generation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Developers: Windows
 
-### How to start Pasta ELN
+### How to start Pasta ELN~~~~
 - Anaconda
   - python -m pasta_eln.gui
   - DOES NOT WORK "pastaELN"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Developers: Windows
 
-### How to start Pasta ELN~~~~
+### How to start Pasta ELN
 - Anaconda
   - python -m pasta_eln.gui
   - DOES NOT WORK "pastaELN"

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -24,6 +24,7 @@ from pasta_eln.GUI.dataverse.main_dialog_base import Ui_MainDialogBase
 from pasta_eln.GUI.dataverse.project_item_frame_base import Ui_ProjectItemFrame
 from pasta_eln.GUI.dataverse.upload_config_dialog import UploadConfigDialog
 from pasta_eln.GUI.dataverse.upload_widget_base import Ui_UploadWidgetFrame
+from pasta_eln.backend import Backend
 from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.data_upload_task import DataUploadTask
 from pasta_eln.dataverse.database_api import DatabaseAPI
@@ -62,7 +63,7 @@ class MainDialog(Ui_MainDialogBase):
     """
     return super(MainDialog, cls).__new__(cls)
 
-  def __init__(self) -> None:
+  def __init__(self, backend: Backend) -> None:
     """
     Initializes the MainDialog.
 
@@ -74,6 +75,7 @@ class MainDialog(Ui_MainDialogBase):
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
     self.instance = DialogExtension()
     super().setupUi(self.instance)
+    self.backend = backend
     self.db_api = DatabaseAPI()
     self.db_api.initialize_database()
     self.is_dataverse_configured: tuple[bool, str] = self.check_if_dataverse_is_configured()
@@ -203,7 +205,8 @@ class MainDialog(Ui_MainDialogBase):
                          widget.uploadProgressBar.setValue,
                          widget.statusLabel.setText,
                          widget.statusIconLabel.setPixmap,
-                         widget.uploadCancelPushButton.clicked))
+                         widget.uploadCancelPushButton.clicked,
+                         self.backend))
         self.upload_manager_task.add_to_queue(task_thread)
         if isinstance(task_thread.task, DataUploadTask):
           task_thread.task.upload_model_created.connect(widget.modelIdLabel.setText)
@@ -430,13 +433,3 @@ class MainDialog(Ui_MainDialogBase):
     width = qt_msgbox_label.fontMetrics().boundingRect(qt_msgbox_label.text()).width()
     qt_msgbox_label.setFixedWidth(width)
     msg_box.exec()
-
-
-if __name__ == "__main__":
-  import sys
-
-  app = QtWidgets.QApplication(sys.argv)
-
-  ui = MainDialog()
-  ui.show()
-  sys.exit(app.exec())

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -80,10 +80,10 @@ class MainDialog(Ui_MainDialogBase):
     self.config_dialog: ConfigDialog | None = None
 
     if self.is_dataverse_configured[0]:
-      self.config_upload_dialog = UploadConfigDialog()
       self.completed_uploads_dialog = CompletedUploads()
       self.edit_metadata_dialog = EditMetadataDialog()
       self.upload_manager_task = UploadQueueManager()
+      self.config_upload_dialog = UploadConfigDialog(self.upload_manager_task.set_concurrent_uploads)
       self.upload_manager_task_thread = TaskThreadExtension(self.upload_manager_task)
 
       # Connect signals and slots
@@ -94,7 +94,6 @@ class MainDialog(Ui_MainDialogBase):
       self.configureUploadPushButton.clicked.connect(self.show_configure_upload)
       self.showCompletedPushButton.clicked.connect(self.show_completed_uploads)
       self.editFullMetadataPushButton.clicked.connect(self.show_edit_metadata)
-      self.config_upload_dialog.config_reloaded.connect(self.upload_manager_task.set_concurrent_uploads)
       self.cancelAllPushButton.clicked.connect(self.upload_manager_task.cancel_all_tasks.emit)
       self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel).clicked.connect(self.close_ui)
       self.instance.closed.connect(self.close_ui)

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -222,13 +222,13 @@ class MainDialog(Ui_MainDialogBase):
     """
     for widget_pos in reversed(range(self.uploadQueueVerticalLayout.count())):
       project_widget = self.uploadQueueVerticalLayout.itemAt(widget_pos).widget()
-      progress_value = project_widget.findChild(QtWidgets.QProgressBar, name="uploadProgressBar").value()
       status_text = project_widget.findChild(QtWidgets.QLabel, name="statusLabel").text()
-      if (progress_value == 100 and status_text in [
+      if (status_text in [
         UploadStatusValues.Finished.name,
         UploadStatusValues.Error.name,
-        UploadStatusValues.Warning.name
-      ]) or status_text == UploadStatusValues.Cancelled.name:
+        UploadStatusValues.Warning.name,
+        UploadStatusValues.Cancelled.name
+      ]):
         project_widget.setParent(None)
 
   def select_deselect_all_projects(self, checked: bool) -> None:

--- a/pasta_eln/GUI/dataverse/main_dialog_base.py
+++ b/pasta_eln/GUI/dataverse/main_dialog_base.py
@@ -123,7 +123,7 @@ class Ui_MainDialogBase(object):
     self.uploadPushButton.setText(_translate("MainDialogBase", "Start upload"))
     self.uploadQueueScrollArea.setToolTip(_translate("MainDialogBase", "<html><head/><body><p><span style=\" font-style:italic;\">Displays the enqueued lists of PASTA projects to be uploaded to dataverse.</span><span style=\" font-style:italic;\">Users can view individual logs for each project upload, cancel each or all of them and also clear all the finished items anytime.</span></p></body></html>"))
     self.clearFinishedPushButton.setToolTip(_translate("MainDialogBase", "Clear all finished/cancelled/error uploads."))
-    self.clearFinishedPushButton.setText(_translate("MainDialogBase", "Clear finished"))
+    self.clearFinishedPushButton.setText(_translate("MainDialogBase", "Clear"))
     self.cancelAllPushButton.setToolTip(_translate("MainDialogBase", "Cancel all the ongoing uploads."))
     self.cancelAllPushButton.setText(_translate("MainDialogBase", "Cancel all"))
     self.showCompletedPushButton.setToolTip(_translate("MainDialogBase", "Show uploaded projects history."))

--- a/pasta_eln/GUI/dataverse/main_dialog_base.ui
+++ b/pasta_eln/GUI/dataverse/main_dialog_base.ui
@@ -205,7 +205,7 @@
               <string>Clear all finished/cancelled/error uploads.</string>
              </property>
              <property name="text">
-              <string>Clear finished</string>
+              <string>Clear</string>
              </property>
             </widget>
            </item>

--- a/pasta_eln/GUI/dataverse/upload_config_dialog.py
+++ b/pasta_eln/GUI/dataverse/upload_config_dialog.py
@@ -8,7 +8,7 @@
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtCore import QObject
@@ -28,7 +28,6 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       It provides methods to load and save the configuration settings.
 
   """
-  config_reloaded = QtCore.Signal()
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -46,7 +45,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     """
     return super(UploadConfigDialog, cls).__new__(cls)
 
-  def __init__(self) -> None:
+  def __init__(self, config_reloaded_callback: Callable[[], None]) -> None:
     """
     Initializes the UploadConfigDialog.
 
@@ -69,6 +68,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     (self.numParallelComboBox.currentTextChanged[str]
      .connect(lambda num: setattr(self.config_model, "parallel_uploads_count", int(num))))
     self.set_data_hierarchy_types()
+    self.config_reloaded_callback = config_reloaded_callback
     self.load_ui()
 
   def load_ui(self) -> None:
@@ -149,7 +149,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       self.logger.error("Failed to load config model!")
       return
     self.db_api.save_config_model(self.config_model)
-    self.config_reloaded.emit()
+    self.config_reloaded_callback()
 
   def show(self) -> None:
     """
@@ -162,12 +162,3 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
         self: The instance of the class.
     """
     self.instance.show()
-
-
-if __name__ == "__main__":
-  import sys
-
-  app = QtWidgets.QApplication(sys.argv)
-  ui = UploadConfigDialog()
-  ui.instance.show()
-  sys.exit(app.exec())

--- a/pasta_eln/dataverse/data_upload_task.py
+++ b/pasta_eln/dataverse/data_upload_task.py
@@ -80,7 +80,7 @@ class DataUploadTask(GenericTaskObject):
     # Create progress thread to update the progress
     self.progress_thread = ProgressUpdaterThread()
     self.progress_thread.progress_update = self.progress_changed
-    self.progress_thread.end.connect(self.progress_thread.deleteLater)
+    self.progress_thread.end.connect(self.progress_thread.quit)
 
   def start_task(self) -> None:
     """

--- a/pasta_eln/dataverse/generic_task_object.py
+++ b/pasta_eln/dataverse/generic_task_object.py
@@ -95,6 +95,9 @@ class GenericTaskObject(QObject):
     """
     self.logger.info("Cleaning up task, id: %s", self.id)
     self.cleaned = True
+    self.cancel.disconnect()
+    self.finish.disconnect()
+    self.start.disconnect()
 
   def finish_task(self) -> None:
     """

--- a/pasta_eln/dataverse/upload_queue_manager.py
+++ b/pasta_eln/dataverse/upload_queue_manager.py
@@ -11,6 +11,7 @@ import logging
 from time import sleep
 
 from PySide6 import QtCore
+from PySide6.QtCore import QTimer
 
 from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.database_api import DatabaseAPI
@@ -88,7 +89,6 @@ class UploadQueueManager(GenericTaskObject):
     self.logger.info("Adding thread task to upload queue, id: %s", upload_task_thread.task.id)
     self.upload_queue.append(upload_task_thread)
     upload_task_thread.task.finish.connect(lambda: self.remove_from_queue(upload_task_thread))
-    upload_task_thread.task.cancel.connect(lambda: self.remove_from_queue(upload_task_thread))
 
   def remove_from_queue(self, upload_task_thread: TaskThreadExtension) -> None:
     """
@@ -108,6 +108,7 @@ class UploadQueueManager(GenericTaskObject):
     if upload_task_thread in self.running_queue:
       self.running_queue.remove(upload_task_thread)
     upload_task_thread.worker_thread.quit()
+    upload_task_thread.task.cleanup()
 
   def start_task(self) -> None:
     """
@@ -159,15 +160,28 @@ class UploadQueueManager(GenericTaskObject):
 
     Explanation:
         This method empties the upload queue by quitting each upload task thread and clearing the upload queue.
-
-    Args:
-        None
-
     """
     self.logger.info("Emptying upload queue..")
     for upload_task_thread in self.upload_queue:
-      upload_task_thread.task.deleteLater()
+      upload_task_thread.worker_thread.quit()
     self.upload_queue.clear()
+
+  def remove_cancelled_tasks(self) -> None:
+    """
+    Removes cancelled tasks from the upload queue.
+
+    Explanation:
+        This method identifies tasks in the upload queue that have been cancelled and removes them from the queue.
+        It also logs the removal of each cancelled task.
+
+    Args:
+        self: The instance of the UploadQueueManager.
+    """
+    self.logger.info("Removing cancelled tasks from the queue..")
+    cancelled_tasks = [upload_task_thread for upload_task_thread in self.upload_queue if
+                       upload_task_thread.task.cancelled]
+    for upload_task_thread in cancelled_tasks:
+      self.remove_from_queue(upload_task_thread)
 
   def cancel_task(self) -> None:
     """
@@ -193,7 +207,8 @@ class UploadQueueManager(GenericTaskObject):
     Args:
         self: The instance of the class.
     """
-
     self.logger.info("Cancelling upload queue and the empty the upload queue..")
     for upload_task_thread in self.upload_queue:
       upload_task_thread.task.cancel.emit()
+    if self.upload_queue:
+      QTimer.singleShot(500, lambda: self.remove_cancelled_tasks())  # pylint: disable=unnecessary-lambda

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -47,6 +47,8 @@ class MainWindow(QMainWindow):
     self.backend = Backend()
     self.comm = Communicate(self.backend)
     self.comm.formDoc.connect(self.formDoc)
+    self.dataverseMainDialog = None
+    self.dataverseConfig = None
 
     # Menubar
     menu = self.menuBar()
@@ -172,11 +174,11 @@ class MainWindow(QMainWindow):
       dataHierarchyForm.instance.exec()
       restart()
     elif command[0] is Command.DATAVERSE_CONFIG:
-      dataverseConfig = ConfigDialog()
-      dataverseConfig.instance.exec()
+      self.dataverseConfig = ConfigDialog()
+      self.dataverseConfig.show()
     elif command[0] is Command.DATAVERSE_MAIN:
-      dataverseMainDialog = MainDialog(self.comm.backend)
-      dataverseMainDialog.instance.exec()
+      self.dataverseMainDialog = MainDialog(self.comm.backend)
+      self.dataverseMainDialog.show()
     elif command[0] is Command.TEST1:
       fileName = QFileDialog.getOpenFileName(self, 'Open file for extractor test', str(Path.home()), '*.*')[0]
       report = self.comm.backend.testExtractor(fileName, outputStyle='html')

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import QMainWindow, QApplication, QFileDialog, QMessageBo
 from qt_material import apply_stylesheet  # of https://github.com/UN-GCPDS/qt-material
 
 from pasta_eln import __version__
+from pasta_eln.GUI.dataverse.config_dialog import ConfigDialog
+from pasta_eln.GUI.dataverse.main_dialog import MainDialog
 from .GUI.body import Body
 from .GUI.config import Configuration
 from .GUI.form import Form
@@ -76,6 +78,8 @@ class MainWindow(QMainWindow):
         Action(name,                         self, [Command.CHANGE_PG, name], changeProjectGroups)
     Action('&Synchronize',                   self, [Command.SYNC],            systemMenu, shortcut='F5')
     Action('&Data hierarchy editor',         self, [Command.DATAHIERARCHY],        systemMenu, shortcut='F8')
+    Action('&Dataverse Configuration',         self, [Command.DATAVERSE_CONFIG],        systemMenu, shortcut='F10')
+    Action('&Upload to Dataverse',         self, [Command.DATAVERSE_MAIN],        systemMenu, shortcut='F11')
     systemMenu.addSeparator()
     Action('&Test extraction from a file',   self, [Command.TEST1],           systemMenu)
     Action('Test &selected item extraction', self, [Command.TEST2],           systemMenu, shortcut='F2')
@@ -167,6 +171,12 @@ class MainWindow(QMainWindow):
       dataHierarchyForm = DataHierarchyEditorDialog(self.comm.backend.db)
       dataHierarchyForm.instance.exec()
       restart()
+    elif command[0] is Command.DATAVERSE_CONFIG:
+      dataverseConfig = ConfigDialog()
+      dataverseConfig.instance.exec()
+    elif command[0] is Command.DATAVERSE_MAIN:
+      dataverseMainDialog = MainDialog(self.comm.backend)
+      dataverseMainDialog.instance.exec()
     elif command[0] is Command.TEST1:
       fileName = QFileDialog.getOpenFileName(self, 'Open file for extractor test', str(Path.home()), '*.*')[0]
       report = self.comm.backend.testExtractor(fileName, outputStyle='html')
@@ -250,6 +260,8 @@ class Command(Enum):
   VERIFY_DB = 14
   SHORTCUTS = 15
   RESTART   = 16
+  DATAVERSE_CONFIG = 17
+  DATAVERSE_MAIN = 18
 
 
 def startMain() -> None:

--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -47,8 +47,8 @@ class MainWindow(QMainWindow):
     self.backend = Backend()
     self.comm = Communicate(self.backend)
     self.comm.formDoc.connect(self.formDoc)
-    self.dataverseMainDialog = None
-    self.dataverseConfig = None
+    self.dataverseMainDialog: MainDialog | None = None
+    self.dataverseConfig: ConfigDialog | None = None
 
     # Menubar
     menu = self.menuBar()

--- a/tests/component_tests/test_dataverse_config_dialog.py
+++ b/tests/component_tests/test_dataverse_config_dialog.py
@@ -62,9 +62,6 @@ def config_dialog(qtbot, mocker, mock_message_box, mock_webbrowser, mock_dataver
   mocker.patch('pasta_eln.GUI.dataverse.config_dialog.QMessageBox', new=mock_message_box)
   mocker.patch('pasta_eln.GUI.dataverse.config_dialog.logging')
   mocker.patch('pasta_eln.GUI.dataverse.config_dialog.webbrowser', mock_webbrowser)
-  # mocker.patch('pasta_eln.GUI.dataverse.config_dialog.get_encrypt_key', return_value=(True, b"test_encrypt_key"))
-  # mocker.patch('pasta_eln.GUI.dataverse.config_dialog.decrypt_data', return_value='decrypted_api_token')
-  # mocker.patch('pasta_eln.GUI.dataverse.config_dialog.encrypt_data', return_value='encrypted_api_token')
   mocker.patch('pasta_eln.GUI.dataverse.config_dialog.check_login_credentials',
                side_effect=mock_check_login_credentials)
   dialog = ConfigDialog()

--- a/tests/component_tests/test_dataverse_upload_config_dialog.py
+++ b/tests/component_tests/test_dataverse_upload_config_dialog.py
@@ -50,7 +50,8 @@ def mock_database_api(mocker):
 def upload_config_dialog(qtbot, mocker, mock_database_api):
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.DatabaseAPI', return_value=mock_database_api)
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.logging')
-  dialog = UploadConfigDialog()
+  callback = mocker.MagicMock()
+  dialog = UploadConfigDialog(callback)
   mocker.resetall()
   qtbot.addWidget(dialog.instance)
   return dialog

--- a/tests/unit_tests/test_dataverse_data_upload_task.py
+++ b/tests/unit_tests/test_dataverse_data_upload_task.py
@@ -133,15 +133,16 @@ class TestDataverseDataUploadTask:
     upload_cancel_clicked_signal_callback.connect.assert_called_once()
     assert task.progress_thread == progress_thread_mock.return_value, "Progress thread should be set"
     assert task.progress_thread.progress_update == task.progress_changed, "Progress thread update signal should be set"
-    task.progress_thread.end.connect.assert_called_once_with(task.progress_thread.deleteLater)
+    task.progress_thread.end.connect.assert_called_once_with(task.progress_thread.quit)
 
   @pytest.mark.parametrize("project_name, project_doc_id, dataverse_login_info, metadata, expected_log_contains", [
     # Success path test cases
     ("Project1", "doc123", {"server_url": "http://example.com", "api_token": "token123", "dataverse_id": "dv123"},
      {"key": "value"}, "Upload initiated for project Project1"),
   ], ids=["success-path"])
-  def test_initialize_success_path(self, mocker, setup_task, mock_upload_model, mock_db_api, project_name, project_doc_id,
-                                 dataverse_login_info, metadata, expected_log_contains):
+  def test_initialize_success_path(self, mocker, setup_task, mock_upload_model, mock_db_api, project_name,
+                                   project_doc_id,
+                                   dataverse_login_info, metadata, expected_log_contains):
     # Arrange
     setup_task.project_name = project_name
     setup_task.project_doc_id = project_doc_id
@@ -416,7 +417,8 @@ class TestDataverseDataUploadTask:
       assert persistent_id is None, "Expected None, got: {}".format(persistent_id)
     else:
       setup_task.dataverse_client.create_and_publish_dataset.assert_called_once_with(dataverse_id,
-                                                                                     {"title": project_name, **metadata})
+                                                                                     {"title": project_name,
+                                                                                      **metadata})
       mock_run.assert_called_once_with(setup_task.dataverse_client.create_and_publish_dataset.return_value)
       if expected_pid:
         setup_task.update_log.assert_called_with(log_message, setup_task.logger.info)

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -330,10 +330,8 @@ class TestDataverseMainDialog(object):
     pytest.param(0, UploadStatusValues.Cancelled.name, True, id="SuccessPath-3-cancelled-with-0-progress"),
     # ID: SuccessPath-4
     pytest.param(100, UploadStatusValues.Cancelled.name, True, id="SuccessPath-4-cancelled-with-100-progress"),
-    # ID: EdgeCase-1 (Progress not 100)
-    pytest.param(99, UploadStatusValues.Finished.name, False, id="EdgeCase-1"),
-    # ID: EdgeCase-2 (Status not in specified list)
-    pytest.param(100, "InProgress", False, id="EdgeCase-2"),
+    # ID: EdgeCase-1 (Status not in a specified list)
+    pytest.param(100, "InProgress", False, id="EdgeCase-1"),
     # ID: ErrorCase-1 (Invalid status value)
     pytest.param(100, "InvalidStatus", False, id="ErrorCase-1"),
   ])
@@ -341,11 +339,9 @@ class TestDataverseMainDialog(object):
     # Arrange
     mock_main_dialog.uploadQueueVerticalLayout = MagicMock()
     widget = MagicMock()
-    progress_bar = mocker.MagicMock()
-    progress_bar.value.return_value = progress_value
     status_label = mocker.MagicMock()
     status_label.text.return_value = status_text
-    widget.findChild.side_effect = lambda x, name: progress_bar if x == QtWidgets.QProgressBar else status_label
+    widget.findChild.side_effect = lambda x, name: status_label
     mock_main_dialog.uploadQueueVerticalLayout.count.return_value = 1
     mock_main_dialog.uploadQueueVerticalLayout.itemAt.return_value = MagicMock(widget=MagicMock(return_value=widget))
 
@@ -357,9 +353,7 @@ class TestDataverseMainDialog(object):
     if expected_removal:
       mock_main_dialog.uploadQueueVerticalLayout.itemAt.assert_called_once_with(0)
       mock_main_dialog.uploadQueueVerticalLayout.itemAt.return_value.widget.assert_called_once()
-      widget.findChild.assert_any_call(QtWidgets.QProgressBar, name="uploadProgressBar")
       widget.findChild.assert_any_call(QtWidgets.QLabel, name="statusLabel")
-      progress_bar.value.assert_called_once()
       status_label.text.assert_called_once()
       widget.setParent.assert_called_once_with(None)
     else:

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -47,7 +47,8 @@ def mock_main_dialog(mocker):
   mocker.patch(
     "pasta_eln.GUI.dataverse.main_dialog.MainDialog.check_if_dataverse_is_configured",
     return_value=(True, "Configured"))
-  return MainDialog()
+  mock_backed = mocker.MagicMock()
+  return MainDialog(mock_backed)
 
 
 class TestDataverseMainDialog(object):
@@ -82,9 +83,10 @@ class TestDataverseMainDialog(object):
     mock_check_if_dataverse_is_configured = mocker.patch(
       "pasta_eln.GUI.dataverse.main_dialog.MainDialog.check_if_dataverse_is_configured",
       return_value=is_configured)
+    mock_backed = mocker.MagicMock()
 
     # Act
-    dialog = MainDialog()
+    dialog = MainDialog(mock_backed)
 
     # Assert
     mock_log.getLogger.assert_called_once_with("pasta_eln.GUI.dataverse.main_dialog.MainDialog")
@@ -309,7 +311,8 @@ class TestDataverseMainDialog(object):
           mock_main_dialog.get_upload_widget.return_value["widget"].uploadProgressBar.setValue,
           mock_main_dialog.get_upload_widget.return_value["widget"].statusLabel.setText,
           mock_main_dialog.get_upload_widget.return_value["widget"].statusIconLabel.setPixmap,
-          mock_main_dialog.get_upload_widget.return_value["widget"].uploadCancelPushButton.clicked
+          mock_main_dialog.get_upload_widget.return_value["widget"].uploadCancelPushButton.clicked,
+          mock_main_dialog.backend
         )
         mock_task_thread.assert_called_once_with(mock_data_upload_task.return_value)
         mock_main_dialog.upload_manager_task.add_to_queue.assert_called_once_with(mock_task_thread.return_value)

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -116,8 +116,6 @@ class TestDataverseMainDialog(object):
       dialog.configureUploadPushButton.clicked.connect.assert_called_once_with(dialog.show_configure_upload)
       dialog.showCompletedPushButton.clicked.connect.assert_called_once_with(dialog.show_completed_uploads)
       dialog.editFullMetadataPushButton.clicked.connect.assert_called_once_with(dialog.show_edit_metadata)
-      dialog.config_upload_dialog.config_reloaded.connect.assert_called_once_with(
-        dialog.upload_manager_task.set_concurrent_uploads)
       dialog.cancelAllPushButton.clicked.connect.assert_called_once_with(
         dialog.upload_manager_task.cancel_all_tasks.emit)
       dialog.buttonBox.button.assert_called_once_with(QtWidgets.QDialogButtonBox.Cancel)
@@ -138,7 +136,6 @@ class TestDataverseMainDialog(object):
       dialog.configureUploadPushButton.clicked.connect.assert_not_called()
       dialog.showCompletedPushButton.clicked.connect.assert_not_called()
       dialog.editFullMetadataPushButton.clicked.connect.assert_not_called()
-      dialog.config_upload_dialog.config_reloaded.connect.assert_not_called()
       dialog.cancelAllPushButton.clicked.connect.assert_not_called()
       dialog.buttonBox.button.assert_not_called()
       dialog.buttonBox.button.return_value.clicked.connect.assert_not_called()


### PR DESCRIPTION
- Added a new function generate_eln_file in data_upload_task.py to integrate the actual ELN generation.
- Added two menu items ('&Dataverse Configuration' and '&Upload to Dataverse') for integrating dataverse modules into PASTA GUI.
- Added and adapted the tests.