### PR TITLE
refactor(dataverse): move initialize_database to backend.py 

### DIFF
--- a/pasta_eln/GUI/configSetupLinux.py
+++ b/pasta_eln/GUI/configSetupLinux.py
@@ -2,13 +2,18 @@
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Any
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QMessageBox, QFileDialog, QProgressBar    # pylint: disable=no-name-in-module
-from ..guiStyle import TextButton, widgetAndLayout
-from ..installationTools import couchdb, configuration, dataHierarchy, exampleData, createShortcut, installLinuxRoot
-from ..fixedStringsJson import setupTextLinux, rootInstallLinux, exampleDataLinux
-from ..miscTools import restart
+from typing import Any, Callable
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QProgressBar, QTextEdit, QVBoxLayout, \
+  QWidget  # pylint: disable=no-name-in-module
+
+from ..dataverse.database_api import DatabaseAPI
+from ..fixedStringsJson import exampleDataLinux, rootInstallLinux, setupTextLinux
 from ..guiCommunicate import Communicate
+from ..guiStyle import TextButton, widgetAndLayout
+from ..installationTools import configuration, couchdb, createShortcut, dataHierarchy, exampleData, installLinuxRoot
+from ..miscTools import restart
+
 
 class ConfigurationSetup(QWidget):
   """
@@ -140,6 +145,8 @@ class ConfigurationSetup(QWidget):
       self.button2.show()
       logging.info('Linux setup analyse end')
     elif command[0] is Command.FINISHED: # What do do when setup is finished: success or unsuccessfully
+      db_api = DatabaseAPI()
+      db_api.initialize_database()
       restart()
       # self.callbackFinished()
     return

--- a/pasta_eln/GUI/configSetupWindows.py
+++ b/pasta_eln/GUI/configSetupWindows.py
@@ -1,14 +1,22 @@
 """ Widget: setup tab inside the configuration dialog window """
-import logging, os, ctypes
+import ctypes
+import logging
+import os
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Any
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QMessageBox, QFileDialog, QProgressBar   # pylint: disable=no-name-in-module
-from ..guiStyle import TextButton, widgetAndLayout
-from ..installationTools import couchdb, configuration, dataHierarchy, exampleData, createShortcut, checkForDotNetVersion
-from ..fixedStringsJson import setupTextWindows, couchDBWindows, exampleDataWindows, restartPastaWindows
-from ..miscTools import restart
+from typing import Any, Callable
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QProgressBar, QTextEdit, QVBoxLayout, \
+  QWidget  # pylint: disable=no-name-in-module
+
+from ..dataverse.database_api import DatabaseAPI
+from ..fixedStringsJson import couchDBWindows, exampleDataWindows, restartPastaWindows, setupTextWindows
 from ..guiCommunicate import Communicate
+from ..guiStyle import TextButton, widgetAndLayout
+from ..installationTools import checkForDotNetVersion, configuration, couchdb, createShortcut, dataHierarchy, \
+  exampleData
+from ..miscTools import restart
+
 
 class ConfigurationSetup(QWidget):
   """
@@ -175,6 +183,8 @@ class ConfigurationSetup(QWidget):
       self.button2.show()
       logging.info('Windows setup analyse end')
     elif command[0] is Command.FINISHED: # What do do when setup is finished: success or unsuccessfully
+      db_api = DatabaseAPI()
+      db_api.initialize_database()
       restart()
       # self.callbackFinished()
     return

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -77,7 +77,6 @@ class MainDialog(Ui_MainDialogBase):
     super().setupUi(self.instance)
     self.backend = backend
     self.db_api = DatabaseAPI()
-    self.db_api.initialize_database()
     self.is_dataverse_configured: tuple[bool, str] = self.check_if_dataverse_is_configured()
     self.config_dialog: ConfigDialog | None = None
 

--- a/pasta_eln/GUI/dataverse/upload_config_dialog.py
+++ b/pasta_eln/GUI/dataverse/upload_config_dialog.py
@@ -58,7 +58,6 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     self.instance = QDialog()
     super().setupUi(self.instance)
     self.db_api = DatabaseAPI()
-    self.db_api.initialize_database()
     self.numParallelComboBox.addItems(map(str, range(2, 6)))
     self.numParallelComboBox.setCurrentIndex(2)
     self.instance.setWindowModality(QtCore.Qt.ApplicationModal)

--- a/pasta_eln/GUI/sidebar.py
+++ b/pasta_eln/GUI/sidebar.py
@@ -9,7 +9,6 @@ from PySide6.QtWidgets import QFrame, QProgressBar, QTreeWidgetItem, QVBoxLayout
 from anytree import Node
 
 from .config import Configuration
-from ..dataverse.database_api import DatabaseAPI
 from ..guiCommunicate import Communicate
 from ..guiStyle import IconButton, TextButton, getColor, showMessage, space, widgetAndLayout
 
@@ -26,8 +25,6 @@ class Sidebar(QWidget):
     if not hasattr(comm.backend, 'db'):  #if no backend
       configWindow = Configuration(comm, 'setup')
       configWindow.exec()
-      db_api = DatabaseAPI()
-      db_api.initialize_database()
     self.openProjectId = ''
 
     # GUI elements

--- a/pasta_eln/GUI/sidebar.py
+++ b/pasta_eln/GUI/sidebar.py
@@ -1,13 +1,18 @@
 """ Sidebar widget that includes the navigation items """
 from enum import Enum
 from typing import Any
-from PySide6.QtGui import QResizeEvent                                                                 # pylint: disable=no-name-in-module
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QTreeWidget, QTreeWidgetItem, QFrame, QProgressBar # pylint: disable=no-name-in-module
-from PySide6.QtCore import Slot                                                                        # pylint: disable=no-name-in-module
-from anytree import PreOrderIter, Node
+
+from PySide6.QtCore import Slot  # pylint: disable=no-name-in-module
+from PySide6.QtGui import QResizeEvent  # pylint: disable=no-name-in-module
+from PySide6.QtWidgets import QFrame, QProgressBar, QTreeWidgetItem, QVBoxLayout, \
+  QWidget  # pylint: disable=no-name-in-module
+from anytree import Node
+
 from .config import Configuration
-from ..guiStyle import TextButton, IconButton, getColor, showMessage, widgetAndLayout, space
+from ..dataverse.database_api import DatabaseAPI
 from ..guiCommunicate import Communicate
+from ..guiStyle import IconButton, TextButton, getColor, showMessage, space, widgetAndLayout
+
 
 class Sidebar(QWidget):
   """ Sidebar widget that includes the navigation items """
@@ -21,6 +26,8 @@ class Sidebar(QWidget):
     if not hasattr(comm.backend, 'db'):  #if no backend
       configWindow = Configuration(comm, 'setup')
       configWindow.exec()
+      db_api = DatabaseAPI()
+      db_api.initialize_database()
     self.openProjectId = ''
 
     # GUI elements

--- a/pasta_eln/backend.py
+++ b/pasta_eln/backend.py
@@ -1,16 +1,25 @@
 """ Python Backend: all operations with the filesystem are here """
-import json, sys, os, importlib, tempfile, logging, traceback
-from threading import Thread
+import importlib
+import json
+import logging
+import os
+import sys
+import tempfile
+import traceback
+from datetime import datetime, timezone
 from pathlib import Path
+from threading import Thread
 from typing import Any, Optional, Union
 from urllib import request
-from datetime import datetime, timezone
-from .mixin_cli import CLI_Mixin
+
 from .database import Database
-from .miscTools import upOut, createDirName, generic_hash, camelCase
-from .handleDictionaries import fillDocBeforeCreate, diffDicts
+from .dataverse.database_api import DatabaseAPI
+from .fixedStringsJson import configurationGUI, defaultConfiguration
+from .handleDictionaries import diffDicts, fillDocBeforeCreate
+from .miscTools import camelCase, createDirName, generic_hash, upOut
 from .miscTools import outputString
-from .fixedStringsJson import defaultConfiguration, configurationGUI
+from .mixin_cli import CLI_Mixin
+
 
 class Backend(CLI_Mixin):
   """
@@ -81,6 +90,8 @@ class Backend(CLI_Mixin):
       return
     if kwargs.get('initViews', False):
       self.db.initDocTypeViews(self.configuration['tableColumnsMax'])
+      db_api = DatabaseAPI()
+      db_api.initialize_database()
     # internal hierarchy structure
     self.hierStack = []
     self.alive     = True

--- a/pasta_eln/backend.py
+++ b/pasta_eln/backend.py
@@ -13,7 +13,6 @@ from typing import Any, Optional, Union
 from urllib import request
 
 from .database import Database
-from .dataverse.database_api import DatabaseAPI
 from .fixedStringsJson import configurationGUI, defaultConfiguration
 from .handleDictionaries import diffDicts, fillDocBeforeCreate
 from .miscTools import camelCase, createDirName, generic_hash, upOut
@@ -90,8 +89,6 @@ class Backend(CLI_Mixin):
       return
     if kwargs.get('initViews', False):
       self.db.initDocTypeViews(self.configuration['tableColumnsMax'])
-      db_api = DatabaseAPI()
-      db_api.initialize_database()
     # internal hierarchy structure
     self.hierStack = []
     self.alive     = True


### PR DESCRIPTION
- Moved the initialize_database() to configSetupLinux.py & configSetupWindows.py, within the installation "Finished" block. This function mainly initializes the database views which are invoked only once, hence moved close to the installation logic.