### PR TITLE
Temporarily block import to not cause errors

### DIFF
--- a/pasta_eln/gui.py
+++ b/pasta_eln/gui.py
@@ -154,12 +154,14 @@ class MainWindow(QMainWindow):
         status = exportELN(self.comm.backend, allProjects, fileName, docTypes)
         showMessage(self, 'Finished', status, 'Information')
     elif command[0] is Command.IMPORT:
-      fileName = QFileDialog.getOpenFileName(self, 'Load data from .eln file', str(Path.home()), '*.eln')[0]
-      if fileName != '':
-        status = importELN(self.comm.backend, fileName)
-        showMessage(self, 'Finished', status, 'Information')
-        self.comm.changeSidebar.emit('redraw')
-        self.comm.changeTable.emit('x0', '')
+      showMessage(self, 'Not fully implemented', 'The eln-file definition develops rapidly. We cannot adopt the import'+\
+                        'in the same speed; hence it is disabled currently.', 'Warning')
+      # fileName = QFileDialog.getOpenFileName(self, 'Load data from .eln file', str(Path.home()), '*.eln')[0]
+      # if fileName != '':
+      #   status = importELN(self.comm.backend, fileName)
+      #   showMessage(self, 'Finished', status, 'Information')
+      #   self.comm.changeSidebar.emit('redraw')
+      #   self.comm.changeTable.emit('x0', '')
     elif command[0] is Command.EXIT:
       self.close()
     # view menu


### PR DESCRIPTION
I commented out a section to prevent users from using a function which is not fully implemented as the .eln file definition evolves rapidly. Repair #295 and #296