### PR TITLE
fix(dataverse): implement fix for config revert during metadata edits

### DIFF
--- a/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
+++ b/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
@@ -279,12 +279,13 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
     if self.metadata:
       self.metadata['datasetVersion']['license'].update({"uri": uri})
 
+  def reload_config(self) -> None:
+    """
+    Reloads the config model from the database.
 
-if __name__ == "__main__":
-  import sys
-
-  app = QtWidgets.QApplication(sys.argv)
-
-  ui = EditMetadataDialog()
-  ui.show()
-  sys.exit(app.exec())
+    Explanation:
+        This method reloads the config model from the database.
+    """
+    self.logger.info("Reloading config model...")
+    self.config_model = self.db_api.get_model(self.db_api.config_doc_id,
+                                              ConfigModel)  # type: ignore[assignment]

--- a/pasta_eln/GUI/dataverse/main_dialog.py
+++ b/pasta_eln/GUI/dataverse/main_dialog.py
@@ -85,10 +85,12 @@ class MainDialog(Ui_MainDialogBase):
       self.completed_uploads_dialog = CompletedUploads()
       self.edit_metadata_dialog = EditMetadataDialog()
       self.upload_manager_task = UploadQueueManager()
-      self.config_upload_dialog = UploadConfigDialog(self.upload_manager_task.set_concurrent_uploads)
+      self.config_upload_dialog = UploadConfigDialog()
       self.upload_manager_task_thread = TaskThreadExtension(self.upload_manager_task)
 
       # Connect signals and slots
+      self.config_upload_dialog.config_reloaded.connect(self.upload_manager_task.set_concurrent_uploads)
+      self.config_upload_dialog.config_reloaded.connect(self.edit_metadata_dialog.reload_config)
       self.uploadPushButton.clicked.connect(self.start_upload)
       self.clearFinishedPushButton.clicked.connect(self.clear_finished)
       self.selectAllPushButton.clicked.connect(lambda: self.select_deselect_all_projects(True))

--- a/pasta_eln/GUI/dataverse/upload_config_dialog.py
+++ b/pasta_eln/GUI/dataverse/upload_config_dialog.py
@@ -8,7 +8,7 @@
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
 import logging
-from typing import Any, Callable
+from typing import Any
 
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtCore import QObject, Qt
@@ -29,6 +29,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       It provides methods to load and save the configuration settings.
 
   """
+  config_reloaded = QtCore.Signal()
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -46,7 +47,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     """
     return super(UploadConfigDialog, cls).__new__(cls)
 
-  def __init__(self, config_reloaded_callback: Callable[[], None]) -> None:
+  def __init__(self) -> None:
     """
     Initializes the UploadConfigDialog.
 
@@ -67,7 +68,6 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
     self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Save).clicked.connect(self.save_ui)
     (self.numParallelComboBox.currentTextChanged[str]
      .connect(lambda num: setattr(self.config_model, "parallel_uploads_count", int(num))))
-    self.config_reloaded_callback = config_reloaded_callback
     self.load_ui()
 
   def load_ui(self) -> None:
@@ -129,7 +129,7 @@ class UploadConfigDialog(Ui_UploadConfigDialog, QObject):
       self.logger.error("Failed to load config model!")
       return
     self.db_api.save_config_model(self.config_model)
-    self.config_reloaded_callback()
+    self.config_reloaded.emit()
 
   def show(self) -> None:
     """

--- a/tests/component_tests/test_dataverse_upload_config_dialog.py
+++ b/tests/component_tests/test_dataverse_upload_config_dialog.py
@@ -51,8 +51,7 @@ def mock_database_api(mocker):
 def upload_config_dialog(qtbot, mocker, mock_database_api):
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.DatabaseAPI', return_value=mock_database_api)
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.logging')
-  callback = mocker.MagicMock()
-  dialog = UploadConfigDialog(callback)
+  dialog = UploadConfigDialog()
   mocker.resetall()
   qtbot.addWidget(dialog.instance)
   return dialog

--- a/tests/unit_tests/test_dataverse_main_dialog.py
+++ b/tests/unit_tests/test_dataverse_main_dialog.py
@@ -113,6 +113,9 @@ class TestDataverseMainDialog(object):
       mock_task_thread_extension.assert_called_once_with(mock_upload_queue_manager.return_value)
       assert dialog.upload_manager_task_thread == mock_task_thread_extension.return_value, "Upload queue manager thread is not set correctly"
 
+      dialog.config_upload_dialog.config_reloaded.connect.assert_any_call(
+        dialog.upload_manager_task.set_concurrent_uploads)
+      dialog.config_upload_dialog.config_reloaded.connect.assert_any_call(dialog.edit_metadata_dialog.reload_config)
       dialog.uploadPushButton.clicked.connect.assert_called_once_with(dialog.start_upload)
       dialog.clearFinishedPushButton.clicked.connect.assert_called_once_with(dialog.clear_finished)
       dialog.selectAllPushButton.clicked.connect.assert_called_once()
@@ -133,6 +136,8 @@ class TestDataverseMainDialog(object):
       mock_edit_metadata_dialog.assert_not_called()
       mock_upload_queue_manager.assert_not_called()
       mock_task_thread_extension.assert_not_called()
+      dialog.config_upload_dialog.config_reloaded.connect.assert_not_called()
+      dialog.config_upload_dialog.config_reloaded.connect.assert_not_called()
       dialog.uploadPushButton.clicked.connect.assert_not_called()
       dialog.clearFinishedPushButton.clicked.connect.assert_not_called()
       dialog.selectAllPushButton.clicked.connect.assert_not_called()

--- a/tests/unit_tests/test_dataverse_upload_config_dialog.py
+++ b/tests/unit_tests/test_dataverse_upload_config_dialog.py
@@ -45,8 +45,7 @@ def mock_dialog(mocker, mock_database_api, mock_config_model):
   mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.get_data_hierarchy_types')
   actual_load_ui = UploadConfigDialog.load_ui
   mocker.patch.object(UploadConfigDialog, 'load_ui')
-  mock_callback = mocker.MagicMock()
-  dialog = UploadConfigDialog(mock_callback)
+  dialog = UploadConfigDialog()
   dialog.load_ui = actual_load_ui
   dialog.db_api.get_config_model.return_value = mock_config_model
   return dialog
@@ -68,10 +67,9 @@ class TestUploadConfigDialog:
     mocker.patch.object(UploadConfigDialog, 'data_hierarchy_types', create=True)
     mocker.patch.object(UploadConfigDialog, 'buttonBox', create=True)
     mock_load_ui = mocker.patch('pasta_eln.GUI.dataverse.upload_config_dialog.UploadConfigDialog.load_ui')
-    mock_callback = mocker.MagicMock()
 
     # Act
-    dialog = UploadConfigDialog(mock_callback)
+    dialog = UploadConfigDialog()
 
     # Assert
     # Assertions to verify that the dialog has been initialized correctly
@@ -184,9 +182,11 @@ class TestUploadConfigDialog:
       (
           "error_no_config_model", "Failed to load config model!", None, "Failed to load config model!", False),
     ])
-  def test_save_ui(self, mock_dialog, mock_config_model, test_id, setup_logger, expected_log_info, expected_log_error,
+  def test_save_ui(self, mocker, mock_dialog, mock_config_model, test_id, setup_logger, expected_log_info,
+                   expected_log_error,
                    expect_callback):
     # Arrange
+    mock_dialog.config_reloaded = mocker.MagicMock()
     mock_dialog.config_model = None if test_id == "error_no_config_model" else mock_config_model
 
     # Act
@@ -199,9 +199,9 @@ class TestUploadConfigDialog:
     if expected_log_error:
       mock_dialog.logger.error.assert_called_with(expected_log_error)
     if expect_callback:
-      mock_dialog.config_reloaded_callback.assert_called_once()
+      mock_dialog.config_reloaded.emit.assert_called_once()
     else:
-      mock_dialog.config_reloaded_callback.assert_not_called()
+      mock_dialog.config_reloaded.emit.assert_not_called()
     if mock_dialog.config_model:
       mock_dialog.db_api.save_config_model.assert_called_with(mock_dialog.config_model)
     else:


### PR DESCRIPTION
- Added config_reloaded signal to upload_config_dialog.py which will be emitted whenever the config is updated. Connected respective slots from EditMetadataDialog and UploadQueueManager which reloads the updated version of config from DB.
- Adapted the tests for the changes done.