### PR TITLE
fix(dataverse): implement fix for edit-error with empty list values

### DIFF
--- a/pasta_eln/GUI/form.py
+++ b/pasta_eln/GUI/form.py
@@ -163,7 +163,7 @@ class Form(QDialog):
                          key, str(value), self.doc['_id'])
         elif isinstance(value, str):    #string
           dataHierarchyItem = [i for group in dataHierarchyNode for i in dataHierarchyNode[group] if i['name']==key]
-          if len(dataHierarchyItem)==1 and 'list' in dataHierarchyItem[0]:       #choice dropdown
+          if len(dataHierarchyItem)==1 and 'list' in dataHierarchyItem[0] and dataHierarchyItem[0]['list']:       #choice dropdown
             setattr(self, f'key_{key}', QComboBox())
             if isinstance(dataHierarchyItem[0]['list'], list):            #dataHierarchy-defined choices
               getattr(self, f'key_{key}').addItems(dataHierarchyItem[0]['list'])


### PR DESCRIPTION
- Added non-empty check for the list field while populating the UI. In the case of empty list, the text field will still be displayed and for a valid list a combo-box will be populated.