### PR TITLE
fix(dataverse): implement fix for the auto-selected items in metadata UI

### DIFF
--- a/pasta_eln/GUI/dataverse/compound_data_type_class.py
+++ b/pasta_eln/GUI/dataverse/compound_data_type_class.py
@@ -1,0 +1,175 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: compound_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import copy
+import logging
+from typing import Any
+
+from PySide6.QtWidgets import QBoxLayout, QHBoxLayout
+
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button, create_date_time_widget, \
+  create_line_edit
+from pasta_eln.dataverse.utils import clear_value, is_date_time_type
+
+
+class CompoundDataTypeClass(DataTypeClass):
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the CompoundDataTypeClass class.
+
+    Explanation:
+        This method creates a new instance of the CompoundDataTypeClass class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the CompoundDataTypeClass class.
+
+    """
+    return super(CompoundDataTypeClass, cls).__new__(cls)
+
+  def __init__(self, context: DataTypeClassContext) -> None:
+    super().__init__(context)
+    self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+  def add_new_entry(self) -> None:
+    new_compound_entry_layout = QHBoxLayout()
+    new_compound_entry_layout.setObjectName("compoundHorizontalLayout")
+    value_template = self.context.meta_field.get('valueTemplate', [{}])[0]
+    for type_val in value_template.values():
+      type_name = type_val.get('typeName')
+      type_value = type_val.get('value')
+      new_compound_entry_layout.addWidget(
+        create_date_time_widget(type_name, '', self.context.parent_frame, type_value)
+        if is_date_time_type(type_name) else
+        create_line_edit(type_name, '', self.context.parent_frame, type_value))
+    add_clear_button(self.context.parent_frame, new_compound_entry_layout)
+    add_delete_button(self.context.parent_frame, new_compound_entry_layout)
+    self.context.main_vertical_layout.addLayout(new_compound_entry_layout)
+
+  def populate_entry(self) -> None:
+    value_template = self.context.meta_field.get('valueTemplate')
+    value = self.context.meta_field.get('value')
+    if self.context.meta_field['multiple']:
+      if isinstance(value, list) and isinstance(value_template, list):
+        if len(value) == 0:
+          empty_entry = copy.deepcopy(value_template[0])
+          clear_value(empty_entry)
+          self.populate_compound_entry(empty_entry, value_template[0])
+        else:
+          for compound in value:
+            self.populate_compound_entry(compound, value_template[0])
+    else:
+      self.context.add_push_button.setDisabled(True)
+      if value:
+        self.populate_compound_entry(value, value_template, False)
+      else:
+        empty_entry = copy.deepcopy(value_template)
+        clear_value(empty_entry)
+        self.populate_compound_entry(empty_entry, value_template, False)
+
+  def save_modifications(self) -> None:
+    if self.context.meta_field.get('multiple'):
+      self.context.meta_field['value'].clear()
+      for layout_pos in range(self.context.main_vertical_layout.count()):
+        compound_horizontal_layout = self.context.main_vertical_layout.itemAt(layout_pos)
+        if isinstance(compound_horizontal_layout, QHBoxLayout):
+          value_template = self.context.meta_field.get('valueTemplate', [{}])[0]
+          self.save_compound_horizontal_layout_values(
+            compound_horizontal_layout,
+            value_template)
+    else:
+      self.context.meta_field['value'] = {}
+      compound_horizontal_layout = self.context.main_vertical_layout.findChild(QHBoxLayout,
+                                                                               "compoundHorizontalLayout")
+      if not isinstance(compound_horizontal_layout, QHBoxLayout):
+        self.logger.error("Compound horizontal layout not found")
+        return
+      value_template = self.context.meta_field.get('valueTemplate')
+      value_template = value_template if isinstance(value_template, dict) else {}
+      self.save_compound_horizontal_layout_values(
+        compound_horizontal_layout,
+        value_template)
+
+  def save_compound_horizontal_layout_values(self,
+                                             compound_horizontal_layout: QBoxLayout,
+                                             value_template: dict[str, Any]) -> None:
+    """
+    Saves the values from the compound horizontal layout to the meta_field.
+
+    Args:
+        self: The instance of the class.
+        compound_horizontal_layout (QBoxLayout): The compound horizontal layout to save.
+        value_template (dict[str, Any]): The template for the compound values.
+
+    Explanation:
+        This method saves the values from the compound horizontal layout to the meta_field.
+        It iterates over the widgets in the compound horizontal layout and updates the meta_field accordingly.
+        The values are extracted from the widgets and stored in the meta_field['value'] attribute.
+        If the widget value is empty or None, the corresponding entry in the meta_field is not updated.
+
+    """
+    if not compound_horizontal_layout.layout():
+      return
+    empty_entry = copy.deepcopy(value_template)
+    update_needed = False
+    layout_items_count = compound_horizontal_layout.count()
+    for widget_pos in range(layout_items_count):
+      widget = compound_horizontal_layout.itemAt(widget_pos).widget()
+      name = widget.objectName().removesuffix("LineEdit").removesuffix("DateTimeEdit")
+      if name in empty_entry:
+        text = widget.text()  # type: ignore[attr-defined]
+        empty_entry[name]['value'] = text if text and text != 'No Value' else ""
+        update_needed = update_needed or empty_entry[name]['value']
+    if update_needed:
+      if isinstance(self.context.meta_field['value'], dict):
+        self.context.meta_field['value'] = {**self.context.meta_field['value'], **empty_entry}
+      elif isinstance(self.context.meta_field['value'], list):
+        self.context.meta_field['value'].append(empty_entry)
+      else:
+        self.context.meta_field['value'] = empty_entry
+
+  def populate_compound_entry(self,
+                              compound_entry: dict[str, Any],
+                              template_entry: dict[str, Any] | None = None,
+                              enable_delete_button: bool = True) -> None:
+    """
+    Populates the compound entry layout based on the compound_entry and template_entry information.
+
+    Args:
+        self: The instance of the class.
+        compound_entry (dict[str, Any]): The compound entry information.
+        template_entry (dict[str, Any] | None, optional): The template entry information. Defaults to None.
+        enable_delete_button (bool, optional): Whether to enable the delete button. Defaults to True.
+
+    Explanation:
+        This method populates the compound entry layout based on the compound_entry and template_entry information.
+        It creates a new QHBoxLayout and adds widgets to it based on the compound_entry values.
+        The widgets can be either QDateTimeEdit or QLineEdit, depending on the type of the compound entry.
+        The template_entry is used to provide default values for the widgets.
+        The new QHBoxLayout is then added to the mainVerticalLayout of the class instance.
+
+    """
+    new_compound_entry_layout = QHBoxLayout()
+    new_compound_entry_layout.setObjectName("compoundHorizontalLayout")
+    for compound_type_name, compound_type in compound_entry.items():
+      template_value = template_entry.get(compound_type_name, {}).get('value') if template_entry else None
+      new_compound_entry_layout.addWidget(
+        create_date_time_widget(compound_type_name, compound_type['value'], self.context.parent_frame, template_value)
+        if is_date_time_type(compound_type_name)
+        else create_line_edit(compound_type_name, compound_type['value'], self.context.parent_frame, template_value))
+    if new_compound_entry_layout.count() > 0:
+      add_clear_button(self.context.parent_frame, new_compound_entry_layout)
+      add_delete_button(self.context.parent_frame, new_compound_entry_layout,
+                        enable_delete_button)
+      self.context.main_vertical_layout.addLayout(new_compound_entry_layout)

--- a/pasta_eln/GUI/dataverse/controlled_vocab_frame.py
+++ b/pasta_eln/GUI/dataverse/controlled_vocab_frame.py
@@ -10,13 +10,17 @@
 import logging
 from typing import Any
 
-from PySide6.QtWidgets import QComboBox, QFrame, QHBoxLayout
+from PySide6.QtWidgets import QFrame
 
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.data_type_class_factory import DataTypeClassFactory
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
 from pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base import Ui_PrimitiveCompoundControlledFrameBase
-from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button
 
 
-class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase):
+class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase, MetadataFrame):
   """
   Represents a controlled vocabulary frame.
 
@@ -55,8 +59,15 @@ class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase):
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
     self.instance = QFrame()
     super().setupUi(self.instance)
-    self.meta_field = meta_field
-    self.addPushButton.clicked.connect(self.add_button_callback)
+    super().__init__(self.instance)
+    self.meta_field: dict[str, Any] = meta_field
+    self.data_type_class_factory: DataTypeClassFactory = DataTypeClassFactory(
+      DataTypeClassContext(self.mainVerticalLayout, self.addPushButton, self.instance, meta_field)
+    )
+    self.data_type: DataTypeClass = self.data_type_class_factory.make_data_type_class(
+      DataTypeClassName(meta_field['typeClass'])
+    )
+    self.addPushButton.clicked.connect(self.add_button_click_handler)
     self.load_ui()
 
   def load_ui(self) -> None:
@@ -73,21 +84,9 @@ class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase):
         self: The instance of the class.
     """
     self.logger.info("Loading controlled vocabulary frame ui..")
-    value_block = self.meta_field.get('value')
-    value_template = self.meta_field.get("valueTemplate")
-    if self.meta_field.get('multiple'):
-      if value_block:
-        for value in value_block:
-          self.add_new_vocab_entry(value_template, value)
-      else:
-        self.add_new_vocab_entry(value_template, None)
-    else:
-      self.add_new_vocab_entry(
-        ["No Value", value_template]
-        if value_template and len(value_template) > 0 else ["No Value"],
-        value_block or "No Value")
+    self.data_type.populate_entry()
 
-  def add_button_callback(self) -> None:
+  def add_button_click_handler(self) -> None:
     """
     Handles the button callback for adding a new vocabulary entry.
 
@@ -99,42 +98,7 @@ class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase):
         self: The instance of the class.
     """
     self.logger.info("Adding new vocabulary entry, value: %s", self.meta_field)
-    value_template = self.meta_field.get('valueTemplate')
-    if self.meta_field.get('multiple'):
-      self.add_new_vocab_entry(value_template, value_template[0]
-      if value_template and len(value_template) > 0 else None)
-    else:
-      self.add_new_vocab_entry(["No Value", value_template]
-                               if value_template and len(value_template) > 0
-                               else ["No Value"], value_template or "No Value")
-
-  def add_new_vocab_entry(self,
-                          controlled_vocabulary: list[str] | None = None,
-                          value: str | None = None) -> None:
-    """
-    Adds a new vocabulary entry to the controlled vocabulary frame.
-
-    Args:
-        controlled_vocabulary (list[str] | None): The list of controlled vocabulary options.
-        value (str | None): The initial value for the vocabulary entry.
-
-    Explanation:
-        This method adds a new vocabulary entry to the controlled vocabulary frame.
-        It creates a new layout with a combo box and a delete button, and adds it to the main vertical layout.
-        The combo box is populated with the controlled vocabulary options, and the initial value is set if provided.
-        The delete button is connected to the delete_layout_and_contents function to handle deletion of the entry.
-    """
-    new_vocab_entry_layout = QHBoxLayout()
-    new_vocab_entry_layout.setObjectName("vocabHorizontalLayout")
-    combo_box = QComboBox(parent=self.instance)
-    combo_box.setObjectName("vocabComboBox")
-    combo_box.setToolTip("Select the controlled vocabulary.")
-    combo_box.addItems(controlled_vocabulary or [])
-    combo_box.setCurrentText(value or "")
-    new_vocab_entry_layout.addWidget(combo_box)
-    add_clear_button(self.instance, new_vocab_entry_layout)
-    add_delete_button(self.instance, new_vocab_entry_layout)
-    self.mainVerticalLayout.addLayout(new_vocab_entry_layout)
+    self.data_type.add_new_entry()
 
   def save_modifications(self) -> None:
     """
@@ -148,21 +112,4 @@ class ControlledVocabFrame(Ui_PrimitiveCompoundControlledFrameBase):
     Args:
         self: The instance of the class.
     """
-    value = self.meta_field.get('value')
-    if self.meta_field['multiple'] and isinstance(value, list):
-      value.clear()
-      for layout_pos in reversed(range(self.mainVerticalLayout.count())):
-        if vocab_horizontal_layout := self.mainVerticalLayout.itemAt(layout_pos).layout():
-          combo_box = vocab_horizontal_layout.itemAt(0).widget()
-          text = combo_box.currentText()
-          if text and text != 'No Value':
-            value.append(text)
-      self.meta_field['value'] = list(set(value))
-    elif layout := self.mainVerticalLayout.findChild(QHBoxLayout,
-                                                     "vocabHorizontalLayout"):
-      if combo_box := layout.itemAt(0).widget():
-        current_text = combo_box.currentText()
-        self.meta_field['value'] = current_text if current_text and current_text != 'No Value' else None
-    else:
-      self.logger.warning("Failed to save modifications, no layout found.")
-    self.logger.info("Saved modifications successfully, value: %s", self.meta_field)
+    self.data_type.save_modifications()

--- a/pasta_eln/GUI/dataverse/controlled_vocabulary_data_type_class.py
+++ b/pasta_eln/GUI/dataverse/controlled_vocabulary_data_type_class.py
@@ -1,0 +1,130 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: controlled_vocabulary_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import logging
+from typing import Any
+
+from PySide6.QtWidgets import QComboBox, QHBoxLayout
+
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button
+
+
+class ControlledVocabularyDataTypeClass(DataTypeClass):
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the ControlledVocabularyDataTypeClass class.
+
+    Explanation:
+        This method creates a new instance of the ControlledVocabularyDataTypeClass class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the ControlledVocabularyDataTypeClass class.
+
+    """
+    return super(ControlledVocabularyDataTypeClass, cls).__new__(cls)
+
+  def __init__(self, context: DataTypeClassContext) -> None:
+    super().__init__(context)
+    self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+  def add_new_entry(self) -> None:
+    value_template = self.context.meta_field.get('valueTemplate')
+    if self.context.meta_field.get('multiple'):
+      self.add_new_vocab_entry(value_template, value_template[0]
+      if value_template and len(value_template) > 0 else None)
+    else:
+      self.add_new_vocab_entry(["No Value", value_template]
+                               if value_template and len(value_template) > 0
+                               else ["No Value"], value_template or "No Value")
+
+  def populate_entry(self) -> None:
+    value_block = self.context.meta_field.get('value')
+    value_template = self.context.meta_field.get("valueTemplate")
+    if self.context.meta_field.get('multiple'):
+      if value_block:
+        for value in value_block:
+          self.add_new_vocab_entry(value_template, value)
+      else:
+        self.add_new_vocab_entry(value_template, None)
+    else:
+      self.add_new_vocab_entry(
+        ["No Value", value_template]
+        if value_template and len(value_template) > 0 else ["No Value"],
+        value_block or "No Value")
+
+  def save_modifications(self) -> None:
+    if self.context.meta_field['multiple']:
+      self.save_multiple_entries()
+    elif layout := self.context.main_vertical_layout.findChild(QHBoxLayout,
+                                                               "vocabHorizontalLayout"):
+      if not isinstance(layout, QHBoxLayout):
+        self.logger.error("vocabHorizontalLayout not found!")
+        return
+      self.save_single_entry(layout)
+    else:
+      self.logger.warning("Failed to save modifications, no layout found.")
+    self.logger.info("Saved modifications successfully, value: %s", self.context.meta_field)
+
+  def save_single_entry(self, layout: QHBoxLayout) -> None:
+    if combo_box := layout.itemAt(0).widget():
+      if not isinstance(combo_box, QComboBox):
+        self.logger.error("Combo box not found!")
+        return
+      current_text = combo_box.currentText()
+      self.context.meta_field['value'] = current_text if current_text and current_text != 'No Value' else None
+
+  def save_multiple_entries(self):
+    value = self.context.meta_field.get('value')
+    if not isinstance(value, list):
+      self.logger.error("Value is not a list")
+      return
+    value.clear()
+    for layout_pos in reversed(range(self.context.main_vertical_layout.count())):
+      if vocab_horizontal_layout := self.context.main_vertical_layout.itemAt(layout_pos).layout():
+        combo_box = vocab_horizontal_layout.itemAt(0).widget()
+        if not isinstance(combo_box, QComboBox):
+          continue
+        text = combo_box.currentText()
+        if text and text != 'No Value':
+          value.append(text)
+    self.context.meta_field['value'] = list(set(value))
+
+  def add_new_vocab_entry(self,
+                          controlled_vocabulary: list[str] | None = None,
+                          value: str | None = None) -> None:
+    """
+    Adds a new vocabulary entry to the controlled vocabulary frame.
+
+    Args:
+        controlled_vocabulary (list[str] | None): The list of controlled vocabulary options.
+        value (str | None): The initial value for the vocabulary entry.
+
+    Explanation:
+        This method adds a new vocabulary entry to the controlled vocabulary frame.
+        It creates a new layout with a combo box and a delete button, and adds it to the main vertical layout.
+        The combo box is populated with the controlled vocabulary options, and the initial value is set if provided.
+        The delete button is connected to the delete_layout_and_contents function to handle deletion of the entry.
+    """
+    new_vocab_entry_layout = QHBoxLayout()
+    new_vocab_entry_layout.setObjectName("vocabHorizontalLayout")
+    combo_box = QComboBox(parent=self.context.parent_frame)
+    combo_box.setObjectName("vocabComboBox")
+    combo_box.setToolTip("Select the controlled vocabulary.")
+    combo_box.addItems(controlled_vocabulary or [])
+    combo_box.setCurrentText(value or "")
+    new_vocab_entry_layout.addWidget(combo_box)
+    add_clear_button(self.context.parent_frame, new_vocab_entry_layout)
+    add_delete_button(self.context.parent_frame, new_vocab_entry_layout)
+    self.context.main_vertical_layout.addLayout(new_vocab_entry_layout)

--- a/pasta_eln/GUI/dataverse/controlled_vocabulary_data_type_class.py
+++ b/pasta_eln/GUI/dataverse/controlled_vocabulary_data_type_class.py
@@ -1,3 +1,4 @@
+""" Represents the controlled vocabulary data type class. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -17,6 +18,9 @@ from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_dele
 
 
 class ControlledVocabularyDataTypeClass(DataTypeClass):
+  """
+  Represents the controlled vocabulary data type class.
+  """
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -36,20 +40,40 @@ class ControlledVocabularyDataTypeClass(DataTypeClass):
     return super(ControlledVocabularyDataTypeClass, cls).__new__(cls)
 
   def __init__(self, context: DataTypeClassContext) -> None:
+    """
+    Initializes a new instance of the ControlledVocabularyDataTypeClass class.
+
+    Explanation:
+        This method initializes a new instance of the ControlledVocabularyDataTypeClass class.
+    Args:
+      context (DataTypeClassContext): The context of the data type class.
+    """
     super().__init__(context)
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
   def add_new_entry(self) -> None:
+    """
+    Adds a new entry to the controlled vocabulary.
+
+    Explanation:
+        This method adds a new entry to the controlled vocabulary.
+    """
     value_template = self.context.meta_field.get('valueTemplate')
     if self.context.meta_field.get('multiple'):
-      self.add_new_vocab_entry(value_template, value_template[0]
-      if value_template and len(value_template) > 0 else None)
+      self.add_new_vocab_entry(value_template, value_template[0] if value_template else None)
     else:
-      self.add_new_vocab_entry(["No Value", value_template]
-                               if value_template and len(value_template) > 0
-                               else ["No Value"], value_template or "No Value")
+      self.add_new_vocab_entry(
+        ["No Value", value_template] if value_template else ["No Value"],
+        value_template or "No Value"
+      )
 
   def populate_entry(self) -> None:
+    """
+    Populates the entry with the current value of the controlled vocabulary.
+
+    Explanation:
+        This method populates the entry with the current value of the controlled vocabulary.
+    """
     value_block = self.context.meta_field.get('value')
     value_template = self.context.meta_field.get("valueTemplate")
     if self.context.meta_field.get('multiple'):
@@ -60,32 +84,56 @@ class ControlledVocabularyDataTypeClass(DataTypeClass):
         self.add_new_vocab_entry(value_template, None)
     else:
       self.add_new_vocab_entry(
-        ["No Value", value_template]
-        if value_template and len(value_template) > 0 else ["No Value"],
-        value_block or "No Value")
+        ["No Value", value_template] if value_template else ["No Value"],
+        value_block or "No Value"
+      )
 
   def save_modifications(self) -> None:
-    if self.context.meta_field['multiple']:
+    """
+    Saves the modifications to the controlled vocabulary.
+
+    Explanation:
+        This method saves the modifications to the controlled vocabulary.
+    """
+    if self.context.meta_field.get('multiple'):
       self.save_multiple_entries()
+      self.logger.info("Saved multiple entry modifications successfully, value: %s", self.context.meta_field)
     elif layout := self.context.main_vertical_layout.findChild(QHBoxLayout,
                                                                "vocabHorizontalLayout"):
       if not isinstance(layout, QHBoxLayout):
         self.logger.error("vocabHorizontalLayout not found!")
         return
       self.save_single_entry(layout)
+      self.logger.info("Saved single entry modification successfully, value: %s", self.context.meta_field)
     else:
       self.logger.warning("Failed to save modifications, no layout found.")
-    self.logger.info("Saved modifications successfully, value: %s", self.context.meta_field)
 
   def save_single_entry(self, layout: QHBoxLayout) -> None:
+    """
+    Saves the single entry to the controlled vocabulary.
+
+    Explanation:
+        This method saves the single entry to the controlled vocabulary.
+    Args:
+      layout (QHBoxLayout): The layout of the single entry.
+    """
     if combo_box := layout.itemAt(0).widget():
       if not isinstance(combo_box, QComboBox):
         self.logger.error("Combo box not found!")
         return
       current_text = combo_box.currentText()
       self.context.meta_field['value'] = current_text if current_text and current_text != 'No Value' else None
+    else:
+      self.context.meta_field['value'] = None
+      self.logger.error("Combo box not found!")
 
-  def save_multiple_entries(self):
+  def save_multiple_entries(self) -> None:
+    """
+    Saves the multiple entries to the controlled vocabulary.
+
+    Explanation:
+        This method saves the multiple entries to the controlled vocabulary.
+    """
     value = self.context.meta_field.get('value')
     if not isinstance(value, list):
       self.logger.error("Value is not a list")

--- a/pasta_eln/GUI/dataverse/data_type_class_base.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_base.py
@@ -1,0 +1,71 @@
+""" Represents the data type class. """
+
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: data_type_class_base.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+
+from abc import abstractmethod
+from typing import Any
+
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+
+
+class DataTypeClass(object):
+
+  def __init__(self, context: DataTypeClassContext) -> None:
+    self.context: DataTypeClassContext = context
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the DataTypeClass class.
+
+    Explanation:
+        This method creates a new instance of the DataTypeClass class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the DataTypeClass class.
+
+    """
+    return super(DataTypeClass, cls).__new__(cls)
+
+  @abstractmethod
+  def add_new_entry(self) -> None:
+    """
+    Saves the modifications made to the data type class.
+
+    Explanation:
+        This method saves the modifications made to the data type class.
+
+    """
+    return
+
+  @abstractmethod
+  def populate_entry(self) -> None:
+    """
+    Saves the modifications made to the data type class.
+
+    Explanation:
+        This method saves the modifications made to the data type class.
+
+    """
+    return
+
+  @abstractmethod
+  def save_modifications(self) -> None:
+    """
+    Saves the modifications made to the data type class.
+
+    Explanation:
+        This method saves the modifications made to the data type class.
+
+    """
+    return

--- a/pasta_eln/GUI/dataverse/data_type_class_base.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_base.py
@@ -1,5 +1,4 @@
 """ Represents the data type class. """
-
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -15,9 +14,26 @@ from typing import Any
 from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
 
 
-class DataTypeClass(object):
+class DataTypeClass:
+  """
+  Represents the base data type class.
+  """
 
   def __init__(self, context: DataTypeClassContext) -> None:
+    """
+    Initializes a new instance of the DataTypeClass class.
+
+    Explanation:
+        This method initializes a new instance of the DataTypeClass class.
+
+    Args:
+      context (DataTypeClassContext): The context of the data type class.
+
+    Raises:
+      TypeError: If the provided context is not of type DataTypeClassContext.
+    """
+    if not isinstance(context, DataTypeClassContext):
+      raise TypeError("context must be of type DataTypeClassContext")
     self.context: DataTypeClassContext = context
 
   def __new__(cls, *_: Any, **__: Any) -> Any:

--- a/pasta_eln/GUI/dataverse/data_type_class_context.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_context.py
@@ -1,3 +1,4 @@
+""" Data type class context. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -11,27 +12,38 @@ from typing import Any
 from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
 
 
-class DataTypeClassContext(object):
+class DataTypeClassContext:
+  """
+  Context class for a DataTypeClass instance
+  """
 
   def __init__(self,
                main_vertical_layout: QVBoxLayout,
                add_push_button: QPushButton,
                parent_frame: QFrame,
                meta_field: dict[str, Any]) -> None:
+    """
+    DataTypeClassContext constructor used by DataTypeClassFactory
+    Args:
+      main_vertical_layout (QVBoxLayout): Main vertical layout in the parent frame
+      add_push_button (QPushButton): Add push button in the parent frame
+      parent_frame (QFrame): Parent frame
+      meta_field (meta_field): Meta field of the data type class
+    """
     super().__init__()
-    if not isinstance(main_vertical_layout, QVBoxLayout):
-      raise ValueError("main_vertical_layout must be a QVBoxLayout!")
-    else:
+    if isinstance(main_vertical_layout, QVBoxLayout):
       self.main_vertical_layout = main_vertical_layout
-    if not isinstance(add_push_button, QPushButton):
-      raise ValueError("add_push_button must be a QPushButton!")
     else:
+      raise ValueError("main_vertical_layout must be a QVBoxLayout!")
+    if isinstance(add_push_button, QPushButton):
       self.add_push_button = add_push_button
-    if not isinstance(parent_frame, QFrame):
-      raise ValueError("parent_frame must be a QFrame!")
     else:
+      raise ValueError("add_push_button must be a QPushButton!")
+    if isinstance(parent_frame, QFrame):
       self.parent_frame = parent_frame
-    if not isinstance(meta_field, dict):
-      raise ValueError("meta_field must be a dict!")
     else:
+      raise ValueError("parent_frame must be a QFrame!")
+    if isinstance(meta_field, dict):
       self.meta_field = meta_field
+    else:
+      raise ValueError("meta_field must be a dict!")

--- a/pasta_eln/GUI/dataverse/data_type_class_context.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_context.py
@@ -1,0 +1,37 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: data_type_class_context.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from typing import Any
+
+from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
+
+
+class DataTypeClassContext(object):
+
+  def __init__(self,
+               main_vertical_layout: QVBoxLayout,
+               add_push_button: QPushButton,
+               parent_frame: QFrame,
+               meta_field: dict[str, Any]) -> None:
+    super().__init__()
+    if not isinstance(main_vertical_layout, QVBoxLayout):
+      raise ValueError("main_vertical_layout must be a QVBoxLayout!")
+    else:
+      self.main_vertical_layout = main_vertical_layout
+    if not isinstance(add_push_button, QPushButton):
+      raise ValueError("add_push_button must be a QPushButton!")
+    else:
+      self.add_push_button = add_push_button
+    if not isinstance(parent_frame, QFrame):
+      raise ValueError("parent_frame must be a QFrame!")
+    else:
+      self.parent_frame = parent_frame
+    if not isinstance(meta_field, dict):
+      raise ValueError("meta_field must be a dict!")
+    else:
+      self.meta_field = meta_field

--- a/pasta_eln/GUI/dataverse/data_type_class_factory.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_factory.py
@@ -1,3 +1,4 @@
+""" Data type class factory. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -16,7 +17,20 @@ from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
 from pasta_eln.GUI.dataverse.primitive_data_type_class import PrimitiveDataTypeClass
 
 
-class DataTypeClassFactory(object):
+class DataTypeClassFactory:
+  """
+  Creates a new instance of the DataTypeClassFactory class.
+
+  Explanation:
+      This method creates a new instance of the DataTypeClassFactory class.
+
+  Args:
+      *_: Variable length argument list.
+      **__: Arbitrary keyword arguments.
+
+  Returns:
+      Any: The new instance of the DataTypeClassFactory class.
+  """
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -36,6 +50,15 @@ class DataTypeClassFactory(object):
     return super(DataTypeClassFactory, cls).__new__(cls)
 
   def __init__(self, context: DataTypeClassContext) -> None:
+    """
+    Initializes a new instance of the DataTypeClassFactory class.
+
+    Explanation:
+        This method initializes a new instance of the DataTypeClassFactory class.
+    Args:
+      context (DataTypeClassContext): The context of the data type class.
+    """
+
     self.context: DataTypeClassContext = context
     self.factory_map: dict[DataTypeClassName, Any] = {
       DataTypeClassName.PRIMITIVE: self.make_primitive_data_type_class,
@@ -44,16 +67,58 @@ class DataTypeClassFactory(object):
     }
 
   def make_data_type_class(self, class_name: DataTypeClassName) -> DataTypeClass:
+    """
+    Creates an instance of a specific data type class based on the provided class name.
+
+    Explanation:
+        This method dynamically creates and returns an instance of a specific data type class based on the given class name.
+
+    Args:
+        class_name (DataTypeClassName): The name of the data type class to instantiate.
+
+    Returns:
+        DataTypeClass: An instance of the specified data type class.
+
+    Raises:
+        ValueError: If the provided data type class name is invalid.
+    """
     if class_name in self.factory_map:
       return self.factory_map[class_name]()
     else:
       raise ValueError(f"Invalid data type class name: {class_name}")
 
   def make_primitive_data_type_class(self) -> DataTypeClass:
+    """
+    Creates an instance of a primitive data type class.
+
+    Explanation:
+        This method creates and returns an instance of a primitive data type class based on the context.
+
+    Returns:
+        DataTypeClass: An instance of a primitive data type class.
+    """
     return PrimitiveDataTypeClass(self.context)
 
   def make_compound_data_type_class(self) -> DataTypeClass:
+    """
+    Creates an instance of a compound data type class.
+
+    Explanation:
+        This method creates and returns an instance of a compound data type class based on the context.
+
+    Returns:
+        DataTypeClass: An instance of a compound data type class.
+    """
     return CompoundDataTypeClass(self.context)
 
   def make_controlled_vocab_data_type_class(self) -> DataTypeClass:
+    """
+    Creates an instance of a controlled vocabulary data type class.
+
+    Explanation:
+        This method creates and returns an instance of a controlled vocabulary data type class based on the context.
+
+    Returns:
+        DataTypeClass: An instance of a controlled vocabulary data type class.
+    """
     return ControlledVocabularyDataTypeClass(self.context)

--- a/pasta_eln/GUI/dataverse/data_type_class_factory.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_factory.py
@@ -1,0 +1,59 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: data_type_class_factory.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from typing import Any
+
+from pasta_eln.GUI.dataverse.compound_data_type_class import CompoundDataTypeClass
+from pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class import ControlledVocabularyDataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.primitive_data_type_class import PrimitiveDataTypeClass
+
+
+class DataTypeClassFactory(object):
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the DataTypeClassFactory class.
+
+    Explanation:
+        This method creates a new instance of the DataTypeClassFactory class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the DataTypeClassFactory class.
+
+    """
+    return super(DataTypeClassFactory, cls).__new__(cls)
+
+  def __init__(self, context: DataTypeClassContext) -> None:
+    self.context: DataTypeClassContext = context
+    self.factory_map: dict[DataTypeClassName, Any] = {
+      DataTypeClassName.PRIMITIVE: self.make_primitive_data_type_class,
+      DataTypeClassName.COMPOUND: self.make_compound_data_type_class,
+      DataTypeClassName.CONTROLLED_VOCAB: self.make_controlled_vocab_data_type_class
+    }
+
+  def make_data_type_class(self, class_name: DataTypeClassName) -> DataTypeClass:
+    if class_name in self.factory_map:
+      return self.factory_map[class_name]()
+    else:
+      raise ValueError(f"Invalid data type class name: {class_name}")
+
+  def make_primitive_data_type_class(self) -> DataTypeClass:
+    return PrimitiveDataTypeClass(self.context)
+
+  def make_compound_data_type_class(self) -> DataTypeClass:
+    return CompoundDataTypeClass(self.context)
+
+  def make_controlled_vocab_data_type_class(self) -> DataTypeClass:
+    return ControlledVocabularyDataTypeClass(self.context)

--- a/pasta_eln/GUI/dataverse/data_type_class_names.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_names.py
@@ -1,0 +1,18 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: data_type_class_names.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+
+from enum import Enum
+
+class DataTypeClassName(Enum):
+    PRIMITIVE = "primitive"
+    COMPOUND = "compound"
+    CONTROLLED_VOCAB = "controlledVocabulary"
+
+    def __str__(self):
+        return self.value

--- a/pasta_eln/GUI/dataverse/data_type_class_names.py
+++ b/pasta_eln/GUI/dataverse/data_type_class_names.py
@@ -1,3 +1,4 @@
+""" Data type class names. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -9,10 +10,27 @@
 
 from enum import Enum
 
-class DataTypeClassName(Enum):
-    PRIMITIVE = "primitive"
-    COMPOUND = "compound"
-    CONTROLLED_VOCAB = "controlledVocabulary"
 
-    def __str__(self):
-        return self.value
+class DataTypeClassName(Enum):
+  """
+  An enumeration representing different data type class names.
+
+  Explanation:
+      This enumeration defines the names of different data type classes such as primitive, compound, and controlled vocabulary.
+
+  """
+  PRIMITIVE = "primitive"
+  COMPOUND = "compound"
+  CONTROLLED_VOCAB = "controlledVocabulary"
+
+  def __str__(self) -> str:
+    """
+    Returns the string representation of the data type class name.
+
+    Explanation:
+        This method returns the string value of the data type class name.
+
+    Returns:
+        str: The string representation of the data type class name.
+    """
+    return self.value

--- a/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
+++ b/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
@@ -150,7 +150,10 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
             self.logger.info("Loading %s metadata type of class: %s...",
                              field['typeName'],
                              field['typeClass'])
-            self.metadata_frame = self.metadata_frame_factory.make_metadata_frame(DataTypeClassName(field['typeClass']), field)
+            if self.metadata_frame:
+              self.metadata_frame.instance.setParent(None)
+            self.metadata_frame = (self.metadata_frame_factory
+                                   .make_metadata_frame(DataTypeClassName(field['typeClass']), field))
             self.metadataScrollVerticalLayout.addWidget(self.metadata_frame.instance)
 
   def change_metadata_block(self, new_metadata_block: str | None = None) -> None:

--- a/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
+++ b/pasta_eln/GUI/dataverse/edit_metadata_dialog.py
@@ -15,10 +15,11 @@ from typing import Any
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtWidgets import QDialog
 
-from pasta_eln.GUI.dataverse.controlled_vocab_frame import ControlledVocabFrame
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
 from pasta_eln.GUI.dataverse.edit_metadata_dialog_base import Ui_EditMetadataDialog
 from pasta_eln.GUI.dataverse.edit_metadata_summary_dialog import EditMetadataSummaryDialog
-from pasta_eln.GUI.dataverse.primitive_compound_frame import PrimitiveCompoundFrame
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
+from pasta_eln.GUI.dataverse.metadata_frame_factory import MetadataFrameFactory
 from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.database_api import DatabaseAPI
 from pasta_eln.dataverse.utils import adjust_type_name, get_formatted_metadata_message
@@ -61,8 +62,8 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
 
     """
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
-    self.primitive_compound_frame: PrimitiveCompoundFrame | None = None
-    self.controlled_vocab_frame: ControlledVocabFrame | None = None
+    self.metadata_frame: MetadataFrame | None = None
+    self.metadata_frame_factory: MetadataFrameFactory = MetadataFrameFactory()
     self.metadata_summary_dialog: EditMetadataSummaryDialog = EditMetadataSummaryDialog(self.save_config)
     self.instance = QDialog()
     super().setupUi(self.instance)
@@ -130,12 +131,9 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
 
     """
     # Save the current modifications
-    if self.primitive_compound_frame:
-      self.primitive_compound_frame.save_modifications()
-      self.primitive_compound_frame.instance.close()
-    if self.controlled_vocab_frame:
-      self.controlled_vocab_frame.save_modifications()
-      self.controlled_vocab_frame.instance.close()
+    if self.metadata_frame:
+      self.metadata_frame.save_modifications()
+      self.metadata_frame.instance.close()
     # Clear the contents of UI elements
     for widget_pos in reversed(range(self.metadataScrollVerticalLayout.count())):
       self.metadataScrollVerticalLayout.itemAt(widget_pos).widget().setParent(None)
@@ -152,13 +150,8 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
             self.logger.info("Loading %s metadata type of class: %s...",
                              field['typeName'],
                              field['typeClass'])
-            match field['typeClass']:
-              case "primitive" | "compound":
-                self.primitive_compound_frame = PrimitiveCompoundFrame(field)
-                self.metadataScrollVerticalLayout.addWidget(self.primitive_compound_frame.instance)
-              case "controlledVocabulary":
-                self.controlled_vocab_frame = ControlledVocabFrame(field)
-                self.metadataScrollVerticalLayout.addWidget(self.controlled_vocab_frame.instance)
+            self.metadata_frame = self.metadata_frame_factory.make_metadata_frame(DataTypeClassName(field['typeClass']), field)
+            self.metadataScrollVerticalLayout.addWidget(self.metadata_frame.instance)
 
   def change_metadata_block(self, new_metadata_block: str | None = None) -> None:
     """
@@ -230,10 +223,8 @@ class EditMetadataDialog(Ui_EditMetadataDialog):
     and displays the updated metadata in the summary dialog.
     """
     self.logger.info("Saving Config Model...")
-    if self.controlled_vocab_frame:
-      self.controlled_vocab_frame.save_modifications()
-    if self.primitive_compound_frame:
-      self.primitive_compound_frame.save_modifications()
+    if self.metadata_frame:
+      self.metadata_frame.save_modifications()
     message = get_formatted_metadata_message(self.metadata or {})
     self.metadata_summary_dialog.summaryTextEdit.setText(message)
     self.metadata_summary_dialog.show()

--- a/pasta_eln/GUI/dataverse/metadata_frame_base.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_base.py
@@ -1,0 +1,64 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: metadata_frame.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from abc import abstractmethod
+from typing import Any
+
+from PySide6.QtWidgets import QFrame
+
+
+class MetadataFrame(object):
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the MetadataFrame class.
+
+    Explanation:
+        This method creates a new instance of the MetadataFrame class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the MetadataFrame class.
+
+    """
+    return super(MetadataFrame, cls).__new__(cls)
+
+  def __init__(self, instance: QFrame) -> None:
+    """
+    Initializes a new instance of the MetadataFrame class.
+
+    Explanation:
+        This method initializes a new instance of the MetadataFrame class.
+
+    """
+    self.instance: QFrame = instance
+
+  @abstractmethod
+  def load_ui(self) -> None:
+    """
+    Loads the UI for the metadata frame.
+
+    Explanation:
+        This method loads the UI for the metadata frame.
+
+    """
+    pass
+
+  @abstractmethod
+  def save_modifications(self) -> None:
+    """
+    Loads the UI for the metadata frame.
+
+    Explanation:
+        This method loads the UI for the metadata frame.
+
+    """
+    pass

--- a/pasta_eln/GUI/dataverse/metadata_frame_base.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_base.py
@@ -1,18 +1,28 @@
+""" Represents the metadata frame. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
 #
 #  Author: Jithu Murugan
-#  Filename: metadata_frame.py
+#  Filename: metadata_frame_base.py
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
+
 from abc import abstractmethod
 from typing import Any
 
 from PySide6.QtWidgets import QFrame
 
 
-class MetadataFrame(object):
+class MetadataFrame:
+  """
+  Represents a metadata frame.
+
+  Explanation:
+      This class represents a metadata frame.
+      It provides methods for loading and saving modifications.
+
+  """
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -44,21 +54,21 @@ class MetadataFrame(object):
   @abstractmethod
   def load_ui(self) -> None:
     """
-    Loads the UI for the metadata frame.
+    Abstract method to load the UI for the metadata frame.
 
     Explanation:
         This method loads the UI for the metadata frame.
 
     """
-    pass
+    return
 
   @abstractmethod
   def save_modifications(self) -> None:
     """
-    Loads the UI for the metadata frame.
+    Abstract method to load the UI for the metadata frame.
 
     Explanation:
         This method loads the UI for the metadata frame.
 
     """
-    pass
+    return

--- a/pasta_eln/GUI/dataverse/metadata_frame_factory.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_factory.py
@@ -1,3 +1,4 @@
+""" Metadata frame factory. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -15,14 +16,45 @@ from pasta_eln.GUI.dataverse.primitive_compound_frame import PrimitiveCompoundFr
 
 
 def make_primitive_compound_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  """
+  Creates a primitive compound frame based on the provided metadata field.
+
+  Explanation:
+      This function creates and returns a primitive compound frame using the given metadata field.
+
+  Args:
+      metadata_field (dict[str, Any]): The metadata field to be used in creating the frame.
+
+  Returns:
+      MetadataFrame: An instance of the primitive compound frame.
+  """
   return PrimitiveCompoundFrame(metadata_field)
 
 
 def make_controlled_vocab_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  """
+  Creates a controlled vocabulary frame based on the provided metadata field.
+
+  Explanation:
+      This function generates a controlled vocabulary frame using the given metadata field.
+
+  Args:
+      metadata_field (dict[str, Any]): The metadata field to be used in creating the frame.
+
+  Returns:
+      MetadataFrame: An instance of the controlled vocabulary frame.
+  """
   return ControlledVocabFrame(metadata_field)
 
 
-class MetadataFrameFactory(object):
+class MetadataFrameFactory:
+  """
+  Creates a new instance of the MetadataFrameFactory class.
+
+  Explanation:
+      This method creates a new instance of the MetadataFrameFactory class.
+
+  """
 
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
@@ -42,6 +74,13 @@ class MetadataFrameFactory(object):
     return super(MetadataFrameFactory, cls).__new__(cls)
 
   def __init__(self) -> None:
+    """
+    Initializes a new instance of the MetadataFrameFactory class.
+
+    Explanation:
+        This method initializes a new instance of the MetadataFrameFactory class.
+
+    """
     self.factory_map: dict[DataTypeClassName, Any] = {
       DataTypeClassName.PRIMITIVE: make_primitive_compound_frame,
       DataTypeClassName.COMPOUND: make_primitive_compound_frame,
@@ -49,6 +88,22 @@ class MetadataFrameFactory(object):
     }
 
   def make_metadata_frame(self, class_name: DataTypeClassName, metadata_field: dict[str, Any]) -> MetadataFrame:
+    """
+    Creates a metadata frame based on the specified data type class name and metadata field.
+
+    Explanation:
+        This method dynamically creates and returns a metadata frame based on the provided data type class name and metadata field.
+
+    Args:
+        class_name (DataTypeClassName): The name of the data type class.
+        metadata_field (dict[str, Any]): The metadata field to be used in the frame creation.
+
+    Returns:
+        MetadataFrame: An instance of the created metadata frame.
+
+    Raises:
+        ValueError: If the provided data type class name is invalid.
+    """
     if class_name in self.factory_map:
       return self.factory_map[class_name](metadata_field)
     else:

--- a/pasta_eln/GUI/dataverse/metadata_frame_factory.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_factory.py
@@ -1,0 +1,55 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: metadata_frame_factory.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from typing import Any
+
+from pasta_eln.GUI.dataverse.controlled_vocab_frame import ControlledVocabFrame
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
+from pasta_eln.GUI.dataverse.primitive_compound_frame import PrimitiveCompoundFrame
+
+
+def make_primitive_compound_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  return PrimitiveCompoundFrame(metadata_field)
+
+
+def make_controlled_vocab_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  return ControlledVocabFrame(metadata_field)
+
+
+class MetadataFrameFactory(object):
+
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the MetadataFrameFactory class.
+
+    Explanation:
+        This method creates a new instance of the MetadataFrameFactory class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the MetadataFrameFactory class.
+
+    """
+    return super(MetadataFrameFactory, cls).__new__(cls)
+
+  def __init__(self) -> None:
+    self.factory_map: dict[DataTypeClassName, Any] = {
+      DataTypeClassName.PRIMITIVE: make_primitive_compound_frame,
+      DataTypeClassName.COMPOUND: make_primitive_compound_frame,
+      DataTypeClassName.CONTROLLED_VOCAB: make_controlled_vocab_frame
+    }
+
+  def make_metadata_frame(self, class_name: DataTypeClassName, metadata_field: dict[str, Any]) -> MetadataFrame:
+    if class_name in self.factory_map:
+      return self.factory_map[class_name](metadata_field)
+    else:
+      raise ValueError(f"Invalid data type class name: {class_name}")

--- a/pasta_eln/GUI/dataverse/metadata_frame_type_names.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_type_names.py
@@ -1,0 +1,8 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: metadata_frame_type_names.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.

--- a/pasta_eln/GUI/dataverse/metadata_frame_type_names.py
+++ b/pasta_eln/GUI/dataverse/metadata_frame_type_names.py
@@ -1,8 +1,0 @@
-#  PASTA-ELN and all its sub-parts are covered by the MIT license.
-#
-#  Copyright (c) 2024
-#
-#  Author: Jithu Murugan
-#  Filename: metadata_frame_type_names.py
-#
-#  You should have received a copy of the license with this file. Please refer the license file for more information.

--- a/pasta_eln/GUI/dataverse/primitive_compound_frame.py
+++ b/pasta_eln/GUI/dataverse/primitive_compound_frame.py
@@ -8,19 +8,20 @@
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
 
-import copy
 import logging
 from typing import Any
 
-from PySide6.QtCore import QDate
-from PySide6.QtWidgets import QBoxLayout, QDateTimeEdit, QFrame, QHBoxLayout, QLineEdit, QVBoxLayout
+from PySide6.QtWidgets import QFrame
 
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.data_type_class_factory import DataTypeClassFactory
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
 from pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base import Ui_PrimitiveCompoundControlledFrameBase
-from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button
-from pasta_eln.dataverse.utils import adjust_type_name, clear_value, is_date_time_type
 
 
-class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase):
+class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase, MetadataFrame):
   """
   Adds a new compound entry.
 
@@ -57,11 +58,18 @@ class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase):
     Args:
         meta_field (dict[str, Any]): The dictionary containing the metadata field information.
     """
-    self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
-    self.instance = QFrame()
+    self.logger: logging.Logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+    self.instance: QFrame = QFrame()
     super().setupUi(self.instance)
-    self.meta_field = meta_field
-    self.addPushButton.clicked.connect(self.add_new_entry)
+    super().__init__(self.instance)
+    self.meta_field: dict[str, Any] = meta_field
+    self.data_type_class_factory: DataTypeClassFactory = DataTypeClassFactory(
+      DataTypeClassContext(self.mainVerticalLayout, self.addPushButton, self.instance, meta_field)
+    )
+    self.data_type: DataTypeClass = self.data_type_class_factory.make_data_type_class(
+      DataTypeClassName(meta_field['typeClass'])
+    )
+    self.addPushButton.clicked.connect(self.add_button_click_handler)
     self.load_ui()
 
   def load_ui(self) -> None:
@@ -84,101 +92,9 @@ class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase):
 
     """
     self.logger.info("Loading UI for %s", self.meta_field)
-    match self.meta_field.get('typeClass'):
-      case "primitive":
-        if not self.meta_field.get('multiple'):
-          self.addPushButton.setDisabled(True)
-        self.populate_primitive_entry()
-      case "compound":
-        value_template = self.meta_field.get('valueTemplate')
-        value = self.meta_field.get('value')
-        if self.meta_field['multiple']:
-          if isinstance(value, list) and isinstance(value_template, list):
-            if len(value) == 0:
-              empty_entry = copy.deepcopy(value_template[0])
-              clear_value(empty_entry)
-              self.populate_compound_entry(empty_entry, value_template[0])
-            else:
-              for compound in value:
-                self.populate_compound_entry(compound, value_template[0])
-        else:
-          self.addPushButton.setDisabled(True)
-          if value:
-            self.populate_compound_entry(value, value_template, False)
-          else:
-            empty_entry = copy.deepcopy(value_template)
-            clear_value(empty_entry)
-            self.populate_compound_entry(empty_entry, value_template, False)
-      case _:
-        self.logger.error("Unknown typeClass: %s", self.meta_field.get('typeClass'))
+    self.data_type.populate_entry()
 
-  def create_line_edit(self,
-                       type_name: str,
-                       type_value: str,
-                       template_value: str | None = None) -> QLineEdit:
-    """
-    Creates a line edit widget.
-
-    Args:
-        type_name (str): The name of the type.
-        type_value (str): The initial value for the line edit.
-        template_value (str | None, optional): The template value for the line edit. Defaults to None.
-
-    Returns:
-        QLineEdit: The created line edit widget.
-
-    Explanation:
-        This function creates a QLineEdit widget with the specified properties.
-        The line edit is set with a placeholder text and a tooltip based on the type name and template value.
-        It has a clear button enabled and is assigned an object name based on the type name.
-        The initial value is set for the line edit.
-
-    """
-    entry_line_edit = QLineEdit(parent=self.instance)
-    adjusted_name = adjust_type_name(type_name)
-    entry_line_edit.setPlaceholderText(f"Enter the {adjusted_name} here.")
-    entry_line_edit.setToolTip(f"Enter the {adjusted_name} value here. e.g. {template_value}")
-    entry_line_edit.setClearButtonEnabled(True)
-    entry_line_edit.setObjectName(f"{type_name}LineEdit")
-    entry_line_edit.setText(type_value)
-    return entry_line_edit
-
-  def create_date_time_widget(self,
-                              type_name: str,
-                              type_value: str,
-                              template_value: str | None = None) -> QDateTimeEdit:
-    """
-    Creates a date-time edit widget.
-
-    Args:
-        type_name (str): The name of the type.
-        type_value (str): The initial value for the date-time edit.
-        template_value (str | None, optional): The template value for the date-time edit. Defaults to None.
-
-    Returns:
-        QDateTimeEdit: The created date-time edit widget.
-
-    Explanation:
-        This function creates a QDateTimeEdit widget with the specified properties.
-        The widget is set with a tooltip based on the type name and template value.
-        It is assigned an object name based on the type name.
-        The initial value is set for the date-time edit, and the display format is set to 'yyyy-MM-dd'.
-
-    """
-    date_time_edit = QDateTimeEdit(parent=self.instance)
-    date_time_edit.setSpecialValueText("No Value")
-    date_time_edit.setMinimumDate(QDate.fromString("0100-01-01", 'yyyy-MM-dd'))
-    adjusted_name = adjust_type_name(type_name)
-    date_time_edit.setToolTip(
-      f"Enter the {adjusted_name} value here. e.g. {template_value}, Minimum possible date is 0100-01-02")
-    date_time_edit.setObjectName(f"{type_name}DateTimeEdit")
-    date_time_edit.setDate(QDate.fromString(type_value, 'yyyy-MM-dd')
-                           if type_value and type_value != 'No Value'
-                           else QDate.fromString("0001-01-01", 'yyyy-MM-dd'))
-    date_time_edit.setDisplayFormat('yyyy-MM-dd')
-    return date_time_edit
-
-  def add_new_entry(self) -> None:
+  def add_button_click_handler(self) -> None:
     """
         Adds a new entry based on the meta_field information.
 
@@ -190,149 +106,13 @@ class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase):
             - For any other 'typeClass' value, it logs an error for unknown typeClass.
 
     """
-    type_name = self.meta_field.get('typeName', '')
-    type_class = self.meta_field.get('typeClass', '')
-    self.logger.info("Adding new entry of type %s, name: %s", type_class, type_name)
+    self.logger.info("Adding new entry of type %s, name: %s",
+                     self.meta_field.get('typeClass', ''),
+                     self.meta_field.get('typeName', ''))
     if not self.meta_field.get('multiple'):
       self.logger.error("Add operation not supported for non-multiple entries")
       return
-    match type_class:
-      case "primitive":
-        new_primitive_entry_layout = self.mainVerticalLayout.findChild(QVBoxLayout,
-                                                                       "primitiveVerticalLayout")
-        value_template = self.meta_field.get('valueTemplate', [""])[0]
-        self.populate_primitive_horizontal_layout(
-          new_primitive_entry_layout,
-          type_name,
-          "",
-          value_template)
-      case "compound":
-        new_compound_entry_layout = QHBoxLayout()
-        new_compound_entry_layout.setObjectName("compoundHorizontalLayout")
-        value_template = self.meta_field.get('valueTemplate', [{}])[0]
-        for type_val in value_template.values():
-          type_name = type_val.get('typeName')
-          type_value = type_val.get('value')
-          new_compound_entry_layout.addWidget(
-            self.create_date_time_widget(type_name, '', type_value)
-            if is_date_time_type(type_name) else
-            self.create_line_edit(type_name, '', type_value))
-        add_clear_button(self.instance, new_compound_entry_layout)
-        add_delete_button(self.instance, new_compound_entry_layout)
-        self.mainVerticalLayout.addLayout(new_compound_entry_layout)
-      case _:
-        self.logger.error("Unknown type class: %s", type_class)
-
-  def populate_compound_entry(self,
-                              compound_entry: dict[str, Any],
-                              template_entry: dict[str, Any] | None = None,
-                              enable_delete_button: bool = True) -> None:
-    """
-    Populates the compound entry layout based on the compound_entry and template_entry information.
-
-    Args:
-        self: The instance of the class.
-        compound_entry (dict[str, Any]): The compound entry information.
-        template_entry (dict[str, Any] | None, optional): The template entry information. Defaults to None.
-        enable_delete_button (bool, optional): Whether to enable the delete button. Defaults to True.
-
-    Explanation:
-        This method populates the compound entry layout based on the compound_entry and template_entry information.
-        It creates a new QHBoxLayout and adds widgets to it based on the compound_entry values.
-        The widgets can be either QDateTimeEdit or QLineEdit, depending on the type of the compound entry.
-        The template_entry is used to provide default values for the widgets.
-        The new QHBoxLayout is then added to the mainVerticalLayout of the class instance.
-
-    """
-    new_compound_entry_layout = QHBoxLayout()
-    new_compound_entry_layout.setObjectName("compoundHorizontalLayout")
-    for compound_type_name, compound_type in compound_entry.items():
-      template_value = template_entry.get(compound_type_name, {}).get('value') if template_entry else None
-      new_compound_entry_layout.addWidget(
-        self.create_date_time_widget(compound_type_name, compound_type['value'], template_value)
-        if is_date_time_type(compound_type_name)
-        else self.create_line_edit(compound_type_name, compound_type['value'], template_value))
-    if new_compound_entry_layout.count() > 0:
-      add_clear_button(self.instance, new_compound_entry_layout)
-      add_delete_button(self.instance, new_compound_entry_layout,
-                        enable_delete_button)
-      self.mainVerticalLayout.addLayout(new_compound_entry_layout)
-
-  def populate_primitive_entry(self) -> None:
-    """
-    Populates the primitive entry layout based on the meta_field information.
-
-    Explanation:
-        This method populates the primitive entry layout based on the meta_field information.
-        It creates a new QVBoxLayout and adds widgets to it based on the meta_field values.
-        The widgets are created using the create_primitive_widget function.
-        The new QVBoxLayout is then added to the mainVerticalLayout of the class instance.
-
-    """
-    type_value = self.meta_field.get('value')
-    type_name = self.meta_field.get('typeName', "")
-    value_template = self.meta_field.get('valueTemplate')
-
-    self.logger.info("Populating new entry of type primitive, name: %s", type_name)
-
-    new_primitive_entry_layout = QVBoxLayout()
-    new_primitive_entry_layout.setObjectName("primitiveVerticalLayout")
-    if self.meta_field.get('multiple') and isinstance(type_value, list):
-      template_first = value_template[0] if isinstance(value_template, list) else ""
-      if not type_value:
-        self.populate_primitive_horizontal_layout(
-          new_primitive_entry_layout,
-          type_name,
-          "",
-          template_first)
-      else:
-        for value in type_value:
-          self.populate_primitive_horizontal_layout(
-            new_primitive_entry_layout,
-            type_name,
-            value,
-            template_first)
-    else:
-      self.populate_primitive_horizontal_layout(
-        new_primitive_entry_layout,
-        type_name,
-        type_value or "",
-        value_template if isinstance(value_template, str) else "",
-        False)
-    self.mainVerticalLayout.addLayout(new_primitive_entry_layout)
-
-  def populate_primitive_horizontal_layout(self,
-                                           new_primitive_entry_layout: QBoxLayout,
-                                           type_name: str,
-                                           type_value: str,
-                                           type_value_template: str,
-                                           enable_delete_button: bool = True) -> None:
-    """
-    Populates the horizontal layout for a primitive entry.
-
-    Args:
-        enable_delete_button (bool): Enable or disable the delete button.
-        new_primitive_entry_layout (QBoxLayout): The layout to populate.
-        type_name (str): The name of the primitive type.
-        type_value (str): The value of the primitive type.
-        type_value_template (str): The template value for the primitive type.
-
-    Explanation:
-        This function populates the horizontal layout for a primitive entry.
-        It creates a new QHBoxLayout and adds widgets to it based on the provided type_name, type_value, and type_value_template.
-        The widgets can be either a QDateTimeEdit or a QLineEdit, depending on the type_name.
-        The new QHBoxLayout is then added to the new_primitive_entry_layout, which is added to the main layout.
-
-    """
-    new_primitive_entry_horizontal_layout = QHBoxLayout()
-    new_primitive_entry_horizontal_layout.setObjectName("primitiveHorizontalLayout")
-    new_primitive_entry_horizontal_layout.addWidget(
-      self.create_date_time_widget(type_name, type_value, type_value_template)
-      if is_date_time_type(type_name) else
-      self.create_line_edit(type_name, type_value, type_value_template))
-    add_clear_button(self.instance, new_primitive_entry_horizontal_layout)
-    add_delete_button(self.instance, new_primitive_entry_horizontal_layout, enable_delete_button)
-    new_primitive_entry_layout.addLayout(new_primitive_entry_horizontal_layout)
+    self.data_type.add_new_entry()
 
   def save_modifications(self) -> None:
     """
@@ -351,74 +131,4 @@ class PrimitiveCompoundFrame(Ui_PrimitiveCompoundControlledFrameBase):
     self.logger.info("Saving changes to meta_field for type, name: %s, class: %s",
                      self.meta_field.get('typeName'),
                      self.meta_field.get('typeClass'))
-    match self.meta_field.get('typeClass'):
-      case "primitive":
-        primitive_vertical_layout = self.mainVerticalLayout.findChild(QVBoxLayout,
-                                                                      "primitiveVerticalLayout")
-        if self.meta_field.get('multiple'):
-          self.meta_field['value'].clear()
-          for widget_pos in range(primitive_vertical_layout.count()):
-            text = primitive_vertical_layout.itemAt(widget_pos).itemAt(0).widget().text()
-            if text and text != "No Value":
-              self.meta_field['value'].append(text)
-        else:
-          text = primitive_vertical_layout.itemAt(0).itemAt(0).widget().text()
-          self.meta_field['value'] = text if text != "No Value" else ""
-      case "compound":
-        if self.meta_field.get('multiple'):
-          self.meta_field['value'].clear()
-          for layout_pos in range(self.mainVerticalLayout.count()):
-            compound_horizontal_layout = self.mainVerticalLayout.itemAt(layout_pos)
-            value_template = self.meta_field.get('valueTemplate', [{}])[0]
-            self.save_compound_horizontal_layout_values(
-              compound_horizontal_layout,
-              value_template)
-        else:
-          self.meta_field['value'] = {}
-          compound_horizontal_layout = self.mainVerticalLayout.findChild(QHBoxLayout,
-                                                                         "compoundHorizontalLayout")
-          value_template = self.meta_field.get('valueTemplate')
-          value_template = value_template if isinstance(value_template, dict) else {}
-          self.save_compound_horizontal_layout_values(
-            compound_horizontal_layout,
-            value_template)
-      case _:
-        self.logger.error("Unsupported typeClass: %s", self.meta_field.get('typeClass'))
-
-  def save_compound_horizontal_layout_values(self,
-                                             compound_horizontal_layout: QBoxLayout,
-                                             value_template: dict[str, Any]) -> None:
-    """
-    Saves the values from the compound horizontal layout to the meta_field.
-
-    Args:
-        self: The instance of the class.
-        compound_horizontal_layout (QBoxLayout): The compound horizontal layout to save.
-        value_template (dict[str, Any]): The template for the compound values.
-
-    Explanation:
-        This method saves the values from the compound horizontal layout to the meta_field.
-        It iterates over the widgets in the compound horizontal layout and updates the meta_field accordingly.
-        The values are extracted from the widgets and stored in the meta_field['value'] attribute.
-        If the widget value is empty or None, the corresponding entry in the meta_field is not updated.
-
-    """
-    if not compound_horizontal_layout.layout():
-      return
-    empty_entry = copy.deepcopy(value_template)
-    update_needed = False
-    layout_items_count = compound_horizontal_layout.count()
-    for widget_pos in range(layout_items_count):
-      widget = compound_horizontal_layout.itemAt(widget_pos).widget()
-      name = widget.objectName().removesuffix("LineEdit").removesuffix("DateTimeEdit")
-      if name in empty_entry:
-        text = widget.text()  # type: ignore[attr-defined]
-        empty_entry[name]['value'] = text if text and text != 'No Value' else ""
-        update_needed = update_needed or empty_entry[name]['value']
-    if update_needed:
-      if isinstance(self.meta_field['value'], dict):
-        self.meta_field['value'] = {**self.meta_field['value'], **empty_entry}
-      elif isinstance(self.meta_field['value'], list):
-        self.meta_field['value'].append(empty_entry)
-      else:
-        self.meta_field['value'] = empty_entry
+    self.data_type.save_modifications()

--- a/pasta_eln/GUI/dataverse/primitive_data_type_class.py
+++ b/pasta_eln/GUI/dataverse/primitive_data_type_class.py
@@ -1,0 +1,155 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: primitive_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+
+import logging
+from typing import Any
+
+from PySide6.QtWidgets import QBoxLayout, QHBoxLayout, QVBoxLayout
+
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button, create_date_time_widget, \
+  create_line_edit, get_primitive_line_edit_text_value
+from pasta_eln.dataverse.utils import is_date_time_type
+
+
+class PrimitiveDataTypeClass(DataTypeClass):
+  def __new__(cls, *_: Any, **__: Any) -> Any:
+    """
+    Creates a new instance of the PrimitiveDataTypeClass class.
+
+    Explanation:
+        This method creates a new instance of the PrimitiveDataTypeClass class.
+
+    Args:
+        *_: Variable length argument list.
+        **__: Arbitrary keyword arguments.
+
+    Returns:
+        Any: The new instance of the PrimitiveDataTypeClass class.
+
+    """
+    return super(PrimitiveDataTypeClass, cls).__new__(cls)
+
+  def __init__(self, context: DataTypeClassContext) -> None:
+    super().__init__(context)
+    self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+  def add_new_entry(self) -> None:
+    new_primitive_entry_layout = self.context.main_vertical_layout.findChild(QVBoxLayout,
+                                                                             "primitiveVerticalLayout")
+    if not isinstance(new_primitive_entry_layout, QVBoxLayout):
+      self.logger.error("Failed to find primitiveVerticalLayout!")
+      return
+    value_template = self.context.meta_field.get('valueTemplate', [""])[0]
+    self.populate_primitive_horizontal_layout(
+      new_primitive_entry_layout,
+      self.context.meta_field.get('typeName', ''),
+      "",
+      value_template)
+
+  def populate_entry(self) -> None:
+    if not self.context.meta_field.get('multiple'):
+      self.context.add_push_button.setDisabled(True)
+    self.populate_primitive_entry()
+
+  def save_modifications(self) -> None:
+    self.logger.info("Saving changes to meta_field for type, name: %s, class: %s",
+                     self.context.meta_field.get('typeName'),
+                     self.context.meta_field.get('typeClass'))
+    primitive_vertical_layout = self.context.main_vertical_layout.findChild(QVBoxLayout,
+                                                                            "primitiveVerticalLayout")
+    if primitive_vertical_layout is None:
+      return
+    if isinstance(primitive_vertical_layout, QVBoxLayout):
+      if self.context.meta_field.get('multiple'):
+        self.context.meta_field['value'].clear()
+        for widget_pos in range(primitive_vertical_layout.count()):
+          text = get_primitive_line_edit_text_value(primitive_vertical_layout, widget_pos)
+          if text and text != "No Value":
+            self.context.meta_field['value'].append(text)
+      else:
+        text = get_primitive_line_edit_text_value(primitive_vertical_layout, 0)
+        self.context.meta_field['value'] = text if text != "No Value" else ""
+
+  def populate_primitive_entry(self) -> None:
+    """
+    Populates the primitive entry layout based on the meta_field information.
+
+    Explanation:
+        This method populates the primitive entry layout based on the meta_field information.
+        It creates a new QVBoxLayout and adds widgets to it based on the meta_field values.
+        The widgets are created using the create_primitive_widget function.
+        The new QVBoxLayout is then added to the mainVerticalLayout of the class instance.
+
+    """
+    type_value = self.context.meta_field.get('value')
+    type_name = self.context.meta_field.get('typeName', "")
+    value_template = self.context.meta_field.get('valueTemplate')
+
+    self.logger.info("Populating new entry of type primitive, name: %s", type_name)
+
+    new_primitive_entry_layout = QVBoxLayout()
+    new_primitive_entry_layout.setObjectName("primitiveVerticalLayout")
+    if self.context.meta_field.get('multiple') and isinstance(type_value, list):
+      template_first = value_template[0] if isinstance(value_template, list) else ""
+      if not type_value:
+        self.populate_primitive_horizontal_layout(
+          new_primitive_entry_layout,
+          type_name,
+          "",
+          template_first)
+      else:
+        for value in type_value:
+          self.populate_primitive_horizontal_layout(
+            new_primitive_entry_layout,
+            type_name,
+            value,
+            template_first)
+    else:
+      self.populate_primitive_horizontal_layout(
+        new_primitive_entry_layout,
+        type_name,
+        type_value or "",
+        value_template if isinstance(value_template, str) else "",
+        False)
+    self.context.main_vertical_layout.addLayout(new_primitive_entry_layout)
+
+  def populate_primitive_horizontal_layout(self,
+                                           new_primitive_entry_layout: QBoxLayout,
+                                           type_name: str,
+                                           type_value: str,
+                                           type_value_template: str,
+                                           enable_delete_button: bool = True) -> None:
+    """
+    Populates the horizontal layout for a primitive entry.
+
+    Args:
+        enable_delete_button (bool): Enable or disable the delete button.
+        new_primitive_entry_layout (QBoxLayout): The layout to populate.
+        type_name (str): The name of the primitive type.
+        type_value (str): The value of the primitive type.
+        type_value_template (str): The template value for the primitive type.
+
+    Explanation:
+        This function populates the horizontal layout for a primitive entry.
+        It creates a new QHBoxLayout and adds widgets to it based on the provided type_name, type_value, and type_value_template.
+        The widgets can be either a QDateTimeEdit or a QLineEdit, depending on the type_name.
+        The new QHBoxLayout is then added to the new_primitive_entry_layout, which is added to the main layout.
+
+    """
+    new_primitive_entry_horizontal_layout = QHBoxLayout()
+    new_primitive_entry_horizontal_layout.setObjectName("primitiveHorizontalLayout")
+    new_primitive_entry_horizontal_layout.addWidget(
+      create_date_time_widget(type_name, type_value, self.context.parent_frame, type_value_template)
+      if is_date_time_type(type_name) else
+      create_line_edit(type_name, type_value, self.context.parent_frame, type_value_template))
+    add_clear_button(self.context.parent_frame, new_primitive_entry_horizontal_layout)
+    add_delete_button(self.context.parent_frame, new_primitive_entry_horizontal_layout, enable_delete_button)
+    new_primitive_entry_layout.addLayout(new_primitive_entry_horizontal_layout)

--- a/pasta_eln/GUI/dataverse/primitive_data_type_class.py
+++ b/pasta_eln/GUI/dataverse/primitive_data_type_class.py
@@ -1,3 +1,4 @@
+""" Primitive data type class. """
 #  PASTA-ELN and all its sub-parts are covered by the MIT license.
 #
 #  Copyright (c) 2024
@@ -20,6 +21,10 @@ from pasta_eln.dataverse.utils import is_date_time_type
 
 
 class PrimitiveDataTypeClass(DataTypeClass):
+  """
+  Represents the primitive data type class.
+  """
+
   def __new__(cls, *_: Any, **__: Any) -> Any:
     """
     Creates a new instance of the PrimitiveDataTypeClass class.
@@ -38,28 +43,62 @@ class PrimitiveDataTypeClass(DataTypeClass):
     return super(PrimitiveDataTypeClass, cls).__new__(cls)
 
   def __init__(self, context: DataTypeClassContext) -> None:
+    """
+    Initializes a new instance of the PrimitiveDataTypeClass.
+
+    Args:
+        context (DataTypeClassContext): The context for the PrimitiveDataTypeClass.
+
+    Explanation:
+        This method initializes a new instance of the PrimitiveDataTypeClass with the provided context.
+    """
     super().__init__(context)
     self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
   def add_new_entry(self) -> None:
+    """
+    Adds a new entry to the primitive data type class.
+
+    Explanation:
+        This method attempts to find the primitiveVerticalLayout in the main vertical layout.
+        If the layout is found, it populates the horizontal layout with the provided type information.
+        If the layout is not found, it logs an error message.
+
+    """
     new_primitive_entry_layout = self.context.main_vertical_layout.findChild(QVBoxLayout,
                                                                              "primitiveVerticalLayout")
     if not isinstance(new_primitive_entry_layout, QVBoxLayout):
       self.logger.error("Failed to find primitiveVerticalLayout!")
       return
-    value_template = self.context.meta_field.get('valueTemplate', [""])[0]
+    value_template = self.context.meta_field.get('valueTemplate')
+    first_value = str(value_template[0]) if value_template else ""
     self.populate_primitive_horizontal_layout(
       new_primitive_entry_layout,
       self.context.meta_field.get('typeName', ''),
       "",
-      value_template)
+      first_value)
 
   def populate_entry(self) -> None:
+    """
+    Populates the entry based on the meta_field information.
+
+    Explanation:
+        This method populates the entry based on the meta_field information.
+        It disables the add push button if the meta_field does not have multiple entries.
+        It then calls the populate_primitive_entry method to populate the entry.
+    """
     if not self.context.meta_field.get('multiple'):
       self.context.add_push_button.setDisabled(True)
     self.populate_primitive_entry()
 
   def save_modifications(self) -> None:
+    """
+    Saves modifications to the meta_field based on the type and class.
+
+    Explanation:
+        This method saves changes to the meta_field based on the type and class information.
+        It retrieves the primitiveVerticalLayout and updates the meta_field value accordingly.
+    """
     self.logger.info("Saving changes to meta_field for type, name: %s, class: %s",
                      self.context.meta_field.get('typeName'),
                      self.context.meta_field.get('typeClass'))
@@ -77,6 +116,8 @@ class PrimitiveDataTypeClass(DataTypeClass):
       else:
         text = get_primitive_line_edit_text_value(primitive_vertical_layout, 0)
         self.context.meta_field['value'] = text if text != "No Value" else ""
+    else:
+      self.logger.error("Failed to find primitiveVerticalLayout!")
 
   def populate_primitive_entry(self) -> None:
     """

--- a/pasta_eln/GUI/dataverse/utility_functions.py
+++ b/pasta_eln/GUI/dataverse/utility_functions.py
@@ -10,7 +10,10 @@
 from typing import Callable
 
 from PySide6.QtCore import QDate, QSize
-from PySide6.QtWidgets import QBoxLayout, QComboBox, QDateTimeEdit, QFrame, QLineEdit, QPushButton, QSizePolicy
+from PySide6.QtWidgets import QBoxLayout, QComboBox, QDateTimeEdit, QFrame, QHBoxLayout, QLineEdit, QPushButton, \
+  QSizePolicy, QVBoxLayout
+
+from pasta_eln.dataverse.utils import adjust_type_name
 
 
 def create_push_button(button_display_text: str,
@@ -101,6 +104,82 @@ def add_clear_button(parent_frame: QFrame,
   )
   parent.addWidget(button)
 
+
+def create_date_time_widget(type_name: str,
+                            type_value: str,
+                            parent_frame: QFrame,
+                            template_value: str | None = None) -> QDateTimeEdit:
+  """
+  Creates a date-time edit widget.
+
+  Args:
+      parent_frame (QFrame): The parent QFrame object.
+      type_name (str): The name of the type.
+      type_value (str): The initial value for the date-time edit.
+      template_value (str | None, optional): The template value for the date-time edit. Defaults to None.
+
+  Returns:
+      QDateTimeEdit: The created date-time edit widget.
+
+  Explanation:
+      This function creates a QDateTimeEdit widget with the specified properties.
+      The widget is set with a tooltip based on the type name and template value.
+      It is assigned an object name based on the type name.
+      The initial value is set for the date-time edit, and the display format is set to 'yyyy-MM-dd'.
+
+  """
+  date_time_edit = QDateTimeEdit(parent=parent_frame)
+  date_time_edit.setSpecialValueText("No Value")
+  date_time_edit.setMinimumDate(QDate.fromString("0100-01-01", 'yyyy-MM-dd'))
+  adjusted_name = adjust_type_name(type_name)
+  date_time_edit.setToolTip(
+    f"Enter the {adjusted_name} value here. e.g. {template_value}, Minimum possible date is 0100-01-02")
+  date_time_edit.setObjectName(f"{type_name}DateTimeEdit")
+  date_time_edit.setDate(QDate.fromString(type_value, 'yyyy-MM-dd')
+                         if type_value and type_value != 'No Value'
+                         else QDate.fromString("0001-01-01", 'yyyy-MM-dd'))
+  date_time_edit.setDisplayFormat('yyyy-MM-dd')
+  return date_time_edit
+
+
+def create_line_edit(type_name: str,
+                     type_value: str,
+                     parent_frame: QFrame,
+                     template_value: str | None = None) -> QLineEdit:
+  """
+  Creates a line edit widget.
+
+  Args:
+      parent_frame (QFrame): The parent QFrame object.
+      type_name (str): The name of the type.
+      type_value (str): The initial value for the line edit.
+      template_value (str | None, optional): The template value for the line edit. Defaults to None.
+
+  Returns:
+      QLineEdit: The created line edit widget.
+
+  Explanation:
+      This function creates a QLineEdit widget with the specified properties.
+      The line edit is set with a placeholder text and a tooltip based on the type name and template value.
+      It has a clear button enabled and is assigned an object name based on the type name.
+      The initial value is set for the line edit.
+
+  """
+  entry_line_edit = QLineEdit(parent=parent_frame)
+  adjusted_name = adjust_type_name(type_name)
+  entry_line_edit.setPlaceholderText(f"Enter the {adjusted_name} here.")
+  entry_line_edit.setToolTip(f"Enter the {adjusted_name} value here. e.g. {template_value}")
+  entry_line_edit.setClearButtonEnabled(True)
+  entry_line_edit.setObjectName(f"{type_name}LineEdit")
+  entry_line_edit.setText(type_value)
+  return entry_line_edit
+
+def get_primitive_line_edit_text_value(primitive_vertical_layout: QVBoxLayout, widget_pos: int) -> str:
+  primitive_horizontal_layout = primitive_vertical_layout.itemAt(widget_pos).widget()
+  if isinstance(primitive_horizontal_layout, QHBoxLayout):
+    line_edit = primitive_horizontal_layout.itemAt(0).widget()
+    if isinstance(line_edit, QLineEdit):
+      return line_edit.text()
 
 def clear_layout_widgets(layout: QBoxLayout) -> None:
   """

--- a/pasta_eln/GUI/dataverse/utility_functions.py
+++ b/pasta_eln/GUI/dataverse/utility_functions.py
@@ -171,15 +171,32 @@ def create_line_edit(type_name: str,
   entry_line_edit.setToolTip(f"Enter the {adjusted_name} value here. e.g. {template_value}")
   entry_line_edit.setClearButtonEnabled(True)
   entry_line_edit.setObjectName(f"{type_name}LineEdit")
-  entry_line_edit.setText(type_value)
+  entry_line_edit.setText(type_value or '')
   return entry_line_edit
 
+
 def get_primitive_line_edit_text_value(primitive_vertical_layout: QVBoxLayout, widget_pos: int) -> str:
-  primitive_horizontal_layout = primitive_vertical_layout.itemAt(widget_pos).widget()
+  """
+  Retrieves the text value of a QLineEdit widget in a primitive vertical layout.
+
+  Args:
+      primitive_vertical_layout (QVBoxLayout): The vertical layout containing the QLineEdit widget.
+      widget_pos (int): The position of the widget in the layout.
+
+  Returns:
+      str: The text value of the QLineEdit widget if found, otherwise None.
+
+  Explanation:
+      This function retrieves the text value of a QLineEdit widget located at the specified position in a primitive vertical layout.
+      It first accesses the horizontal layout at the given position and then checks if the widget is a QLineEdit before returning its text value.
+  """
+  primitive_horizontal_layout = primitive_vertical_layout.itemAt(widget_pos).layout()
   if isinstance(primitive_horizontal_layout, QHBoxLayout):
     line_edit = primitive_horizontal_layout.itemAt(0).widget()
     if isinstance(line_edit, QLineEdit):
       return line_edit.text()
+  return ''
+
 
 def clear_layout_widgets(layout: QBoxLayout) -> None:
   """

--- a/pasta_eln/GUI/dataverse/utility_functions.py
+++ b/pasta_eln/GUI/dataverse/utility_functions.py
@@ -54,20 +54,17 @@ def add_delete_button(parent_frame: QFrame,
                       enabled: bool = True) -> None:
   """
   Adds a delete button to the layout.
+
   Args:
       parent_frame (QFrame): The parent QFrame object.
       parent (QBoxLayout): The parent QBoxLayout object.
       enabled (bool, optional): Whether the button should be enabled or disabled.
       Defaults to True.
 
-  Returns:
-      QPushButton: The created delete button widget.
-
   Explanation:
       This function creates a QPushButton widget with the specified properties and adds it to the parent layout.
       The button is labeled as "Delete" and can be enabled or disabled based on the 'enabled' parameter.
       It is connected to a lambda function that calls the 'delete' function with the parent QBoxLayout as an argument.
-
   """
   delete_push_button = create_push_button(
     "Delete",
@@ -82,6 +79,18 @@ def add_delete_button(parent_frame: QFrame,
 
 def add_clear_button(parent_frame: QFrame,
                      parent: QBoxLayout) -> None:
+  """
+  Adds a clear button to the layout.
+
+  Args:
+      parent_frame (QFrame): The parent QFrame object.
+      parent (QBoxLayout): The parent QBoxLayout object.
+
+  Explanation:
+      This function creates a QPushButton widget with the specified properties and adds it to the parent layout.
+      The button is labeled as "Clear" and can be connected to a lambda function that calls the 'clear' function
+      with the parent QBoxLayout as an argument.
+  """
   button = create_push_button(
     "Clear",
     "clearPushButton",

--- a/pasta_eln/GUI/dataverse/utility_functions.py
+++ b/pasta_eln/GUI/dataverse/utility_functions.py
@@ -1,0 +1,134 @@
+""" Utility function used by the dataverse module """
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: utility_functions.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from typing import Callable
+
+from PySide6.QtCore import QDate, QSize
+from PySide6.QtWidgets import QBoxLayout, QComboBox, QDateTimeEdit, QFrame, QLineEdit, QPushButton, QSizePolicy
+
+
+def create_push_button(button_display_text: str,
+                       object_name: str,
+                       tooltip: str,
+                       parent_frame: QFrame,
+                       parent_layout: QBoxLayout,
+                       clicked_callback: Callable[[QBoxLayout], None]) -> QPushButton:
+  """
+  Creates a push button widget with specified properties.
+
+  Args:
+    button_display_text (str): The text to display on the button.
+    object_name (str): The object name for the button.
+    tooltip (str): The tooltip text for the button.
+    parent_frame (QFrame): The parent QFrame object.
+    parent_layout (QBoxLayout): The parent QBoxLayout object.
+    clicked_callback (Callable[[QBoxLayout], None]): The callback function to execute when the button is clicked.
+
+
+  Returns:
+    QPushButton: The created push button widget.
+  """
+  push_button = QPushButton(parent=parent_frame)
+  push_button.setText(button_display_text)
+  push_button.setObjectName(object_name)
+  push_button.setToolTip(tooltip)
+  size_policy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+  size_policy.setHorizontalStretch(0)
+  size_policy.setVerticalStretch(0)
+  size_policy.setHeightForWidth(push_button.sizePolicy().hasHeightForWidth())
+  push_button.setSizePolicy(size_policy)
+  push_button.setMinimumSize(QSize(100, 0))
+  push_button.clicked.connect(lambda: clicked_callback(parent_layout))
+  return push_button
+
+
+def add_delete_button(parent_frame: QFrame,
+                      parent: QBoxLayout,
+
+                      enabled: bool = True) -> None:
+  """
+  Adds a delete button to the layout.
+  Args:
+      parent_frame (QFrame): The parent QFrame object.
+      parent (QBoxLayout): The parent QBoxLayout object.
+      enabled (bool, optional): Whether the button should be enabled or disabled.
+      Defaults to True.
+
+  Returns:
+      QPushButton: The created delete button widget.
+
+  Explanation:
+      This function creates a QPushButton widget with the specified properties and adds it to the parent layout.
+      The button is labeled as "Delete" and can be enabled or disabled based on the 'enabled' parameter.
+      It is connected to a lambda function that calls the 'delete' function with the parent QBoxLayout as an argument.
+
+  """
+  delete_push_button = create_push_button(
+    "Delete",
+    "deletePushButton",
+    "Delete this particular entry.",
+    parent_frame,
+    parent,
+    delete_layout_and_contents)
+  delete_push_button.setEnabled(enabled)
+  parent.addWidget(delete_push_button)
+
+
+def add_clear_button(parent_frame: QFrame,
+                     parent: QBoxLayout) -> None:
+  button = create_push_button(
+    "Clear",
+    "clearPushButton",
+    "Clear this particular entry.",
+    parent_frame,
+    parent,
+    clear_layout_widgets,
+  )
+  parent.addWidget(button)
+
+
+def clear_layout_widgets(layout: QBoxLayout) -> None:
+  """
+  Clears the widgets in the given layout by resetting QLineEdit, QComboBox, and QDateTimeEdit widgets.
+
+  Args:
+    layout (QBoxLayout): The layout containing the widgets to be cleared.
+  """
+  if layout is None:
+    return
+  for widget_pos in reversed(range(layout.count())):
+    if item := layout.itemAt(widget_pos):
+      widget = item.widget()
+      if isinstance(widget, QLineEdit):
+        widget.clear()
+      elif isinstance(widget, QComboBox):
+        widget.setCurrentText("No Value")
+      elif isinstance(widget, QDateTimeEdit):
+        widget.setDate(QDate.fromString("01/01/0001", "dd/MM/yyyy"))
+
+
+def delete_layout_and_contents(layout: QBoxLayout) -> None:
+  """
+  Deletes the layout and its contents.
+
+  Args:
+      layout (QBoxLayout): The layout to delete.
+
+  Explanation:
+      This function deletes the given layout and its contents.
+      It iterates over the widgets in the layout and removes them from their parent.
+      Finally, it sets the layout's parent to None.
+
+  """
+  if layout is None:
+    return
+  for widget_pos in reversed(range(layout.count())):
+    if item := layout.itemAt(widget_pos):
+      item.widget().setParent(None)
+  layout.setParent(None)

--- a/pasta_eln/dataverse/utils.py
+++ b/pasta_eln/dataverse/utils.py
@@ -20,7 +20,6 @@ from typing import Any, Callable, Type
 
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QImage, QPixmap
-from PySide6.QtWidgets import QBoxLayout
 from cryptography.fernet import Fernet, InvalidToken
 from qtawesome import icon
 
@@ -158,20 +157,47 @@ def set_template_values(logger: Logger, metadata: dict[str, Any]) -> None:
   for _, metablock in metadata['datasetVersion']['metadataBlocks'].items():
     for field in metablock['fields']:
       match field['typeClass']:
-        case "primitive" | "controlledVocabulary":
-          # Array of primitive types
+        case "primitive":
+          set_field_template_value(field)
+        case "controlledVocabulary":
+          set_field_template_value(field)
           if field['multiple']:
-            field['valueTemplate'] = field['value'].copy()
-            field['value'].clear()
-          # Single primitive type, set to empty string
-          else:
-            field['valueTemplate'] = field['value']
-            field['value'] = ""
+            field['valueTemplate'].insert(0, "No Value")
         case "compound":
           field['valueTemplate'] = field['value'].copy()
           field['value'].clear()
         case _:
           logger.warning(f"Unsupported type class: {field['typeClass']}")
+
+
+def set_field_template_value(field: dict[str, Any]) -> None:
+  """
+  Set template values in the field.
+
+  This function sets template values in the field based on the type of the field.
+  If the field is a multiple type, the value template is set to a copy of the value, and the value is cleared.
+  If the field is a single type, the value template is set to the value, and the value is set to an empty string.
+
+  Args:
+      field (dict[str, Any]): The field dictionary to update.
+
+  Examples:
+      >>> field = {'typeClass': 'primitive', 'multiple': False, 'value': 'Example'}
+      >>> set_field_template_value(field)
+      >>> field
+      {'typeClass': 'primitive', 'multiple': False, 'value': '', 'valueTemplate': 'Example'}
+  """
+  if field.get('multiple'):
+    if 'value' in field and field['value']:
+      field['valueTemplate'] = field['value'].copy()
+      field['value'].clear()
+    else:
+      field['value'] = []
+      field['valueTemplate'] = []
+  else:
+    field['valueTemplate'] = field.get('value')
+    if 'value' in field:
+      field['value'] = ""
 
 
 def check_if_minimal_metadata_exists(logger: Logger,
@@ -596,27 +622,6 @@ def is_date_time_type(type_name: str) -> bool:
     map(type_name.lower().__contains__, ["date", "time"]))
 
 
-def delete_layout_and_contents(layout: QBoxLayout) -> None:
-  """
-  Deletes the layout and its contents.
-
-  Args:
-      layout (QBoxLayout): The layout to delete.
-
-  Explanation:
-      This function deletes the given layout and its contents.
-      It iterates over the widgets in the layout and removes them from their parent.
-      Finally, it sets the layout's parent to None.
-
-  """
-  if layout is None:
-    return
-  for widget_pos in reversed(range(layout.count())):
-    if item := layout.itemAt(widget_pos):
-      item.widget().setParent(None)
-  layout.setParent(None)
-
-
 def get_formatted_message(missing_metadata: dict[str, list[str]]) -> str:
   """
   Returns a formatted message with missing metadata information.
@@ -712,7 +717,7 @@ def get_formatted_metadata_message(metadata: dict[str, Any]) -> str:
         else:
           message += f"<i style=\"color:Gray\"><li>{field['value']}</li></i></ul>"
     if not has_value:
-      message += "<li style=\"color:#737373\">No value</li></ul>"
+      message += "<li style=\"color:#737373\">No Value</li></ul>"
     message += "</ul>"
   message += "</html>"
   return message

--- a/pasta_eln/dataverse/utils.py
+++ b/pasta_eln/dataverse/utils.py
@@ -706,6 +706,10 @@ def get_formatted_metadata_message(metadata: dict[str, Any]) -> str:
               message += f"<li style=\"color:Gray\">{adjust_type_name(value['typeName'])}: <i>{value['value']}</li></i>"
             message += "</ul>"
           message += "</ul>"
+        elif not field["multiple"] and field["typeClass"] == "compound":
+          for _, value in field['value'].items():
+            message += f"<li style=\"color:Gray\">{adjust_type_name(value['typeName'])}: <i>{value['value']}</li></i>"
+          message += "</ul>"
         elif field["multiple"] and field["typeClass"] == "controlledVocabulary":
           for field_value in field['value']:
             message += f"<i style=\"color:Gray\"><li>{field_value}</li></i>"

--- a/pasta_eln/webclient/http_client.py
+++ b/pasta_eln/webclient/http_client.py
@@ -10,7 +10,7 @@
 import logging
 from typing import Any, Union
 
-from aiohttp import BasicAuth, ClientResponse, ClientSession
+from aiohttp import BasicAuth, ClientResponse, ClientSession, ClientTimeout
 
 from pasta_eln.utils import handle_http_client_exception
 
@@ -85,7 +85,7 @@ class AsyncHttpClient:
       async with session.get(base_url,
                              params=request_params,
                              headers=request_headers,
-                             timeout=timeout if timeout is not None else self.session_timeout,
+                             timeout=ClientTimeout(total=timeout if timeout is not None else self.session_timeout),
                              auth=auth) as response:
         result = await prepare_result(response)
     return result
@@ -125,7 +125,7 @@ class AsyncHttpClient:
       async with session.post(base_url,
                               headers=request_headers,
                               params=request_params,
-                              timeout=timeout if timeout is not None else self.session_timeout,
+                              timeout=ClientTimeout(total=timeout if timeout is not None else self.session_timeout),
                               json=json,
                               data=data,
                               auth=auth) as response:
@@ -167,7 +167,7 @@ class AsyncHttpClient:
       async with session.delete(base_url,
                                 headers=request_headers,
                                 params=request_params,
-                                timeout=timeout if timeout is not None else self.session_timeout,
+                                timeout=ClientTimeout(total=timeout if timeout is not None else self.session_timeout),
                                 json=json,
                                 data=data,
                                 auth=auth) as response:

--- a/tests/common/fixtures.py
+++ b/tests/common/fixtures.py
@@ -74,6 +74,7 @@ def terminology_lookup_mock(mocker) -> TerminologyLookupService:
 @fixture()
 def http_client_mock(mocker) -> AsyncHttpClient:
   mocker.patch('pasta_eln.webclient.http_client.logging.getLogger')
+  mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
   return AsyncHttpClient()
 
 
@@ -205,7 +206,7 @@ def data_hierarchy_doc_mock(mocker) -> Document:
   mock_doc.pop.side_effect = mock_doc_content.pop
   mock_doc.keys.side_effect = mock_doc_content.keys
   mock_doc.types.side_effect = lambda: {data: mock_doc_content[data] for data in mock_doc_content if
-    type(mock_doc_content[data]) is dict}
+                                        type(mock_doc_content[data]) is dict}
   mock_doc.types_list.side_effect = mocker.MagicMock(
     return_value=[data for data in mock_doc_content if type(mock_doc_content[data]) is dict])
   return mock_doc

--- a/tests/component_tests/test_dataverse_edit_metadata_dialog.py
+++ b/tests/component_tests/test_dataverse_edit_metadata_dialog.py
@@ -145,9 +145,9 @@ class TestDataverseEditMetadataDialog:
         QDialogButtonBox.Save).isVisible(), "EditMetadataDialog Save button should be shown!"
       assert edit_metadata_dialog.buttonBox.button(
         QDialogButtonBox.Cancel).isVisible(), "EditMetadataDialog Cancel button should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
-      vocab_horizontal_layout = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChild(
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      vocab_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QHBoxLayout,
         "vocabHorizontalLayout")
       assert vocab_horizontal_layout, "EditMetadataDialog vocab_horizontal_layout should be present in mainVerticalLayout!"
@@ -160,7 +160,7 @@ class TestDataverseEditMetadataDialog:
       delete_button = vocab_horizontal_layout.itemAt(2).widget()
       assert delete_button.isVisible(), "EditMetadataDialog controlled_vocab_frame delete button should be shown!"
       assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete button should be enabled!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
 
       assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Minimal", "minimalFullComboBox must be initialized with default Minimal option"
       assert edit_metadata_dialog.typesComboBox.currentText() == "Subject", "typesComboBox must be initialized with default 'Title' option"
@@ -396,10 +396,10 @@ class TestDataverseEditMetadataDialog:
             assert widget.placeholderText() == placeholderTexts[
               i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
       elif test_id == "success_case_select_astronomy_metadata" or test_id == "success_case_life_sciences_metadata":
-        assert edit_metadata_dialog.controlled_vocab_frame, "EditMetadataDialog controlled_vocab_frame should be present!"
-        assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
-        assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
-        vocab_horizontal_layout = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChild(
+        assert edit_metadata_dialog.metadata_frame, "EditMetadataDialog controlled_vocab_frame should be present!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+        vocab_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
           QHBoxLayout,
           "vocabHorizontalLayout")
         assert vocab_horizontal_layout, "EditMetadataDialog vocab_horizontal_layout should be present!"
@@ -521,7 +521,6 @@ class TestDataverseEditMetadataDialog:
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos])
-
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
     assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
     qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
@@ -690,19 +689,19 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Design Type', "typesComboBox must be initialized with 'Study Design Type' option"
 
-      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
 
-      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+      vocab_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "vocabHorizontalLayout")
       assert vocab_horizontal_layouts, "EditMetadataDialog vocab_horizontal_layouts should be present!"
       assert len(vocab_horizontal_layouts) == 1, "EditMetadataDialog vocab_horizontal_layouts should have 1 item!"
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      vocab_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "vocabHorizontalLayout")
       assert len(
@@ -755,19 +754,19 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Design Type', "typesComboBox must be initialized with 'Study Design Type' option"
 
-      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
 
-      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+      vocab_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "vocabHorizontalLayout")
       assert vocab_horizontal_layouts, "EditMetadataDialog vocab_horizontal_layouts should be present!"
       assert len(vocab_horizontal_layouts) == 1, "EditMetadataDialog vocab_horizontal_layouts should have 1 item!"
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
-      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      vocab_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "vocabHorizontalLayout")
       assert len(
@@ -1103,34 +1102,33 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with Life Sciences Metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Study Factor Type', delay=10)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Factor Type', "typesComboBox must be initialized with Study Factor Type option"
-      assert not edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should not be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 2 children!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 2 children!"
       combo_box_items = ['No Value', 'Age', 'Biomarkers', 'Cell Surface Markers', 'Developmental Stage']
-      combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(0).widget()
+      combo_box = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(0).widget()
       assert combo_box.isEnabled(), "EditMetadataDialog controlled_vocab_frame combo_box should be enabled!"
       assert combo_box.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog controlled_vocab_frame combo_box should have right tooltip!"
       assert [combo_box.itemText(i) for i in range(
         combo_box.count())] == combo_box_items, "EditMetadataDialog controlled_vocab_frame combo_box should have right options!"
       assert combo_box.currentText() == 'No Value', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
-      clear_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget()
+      clear_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget()
       assert clear_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame clear_button should be enabled!"
       assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog controlled_vocab_frame clear_button should have right tooltip!"
-      delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
+      delete_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
       assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete_button should be enabled!"
       assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
 
       # Add new field items
       for _ in range(4):
-        qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton,
+        qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton,
                          Qt.LeftButton)
 
       # Check if the new field items are added in UI
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 6, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
-      for pos in range(1, edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count()):
-        combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 6, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        combo_box = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert combo_box.isEnabled(), "EditMetadataDialog controlled_vocab_frame combo_box should be enabled!"
         assert combo_box.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog controlled_vocab_frame combo_box should have right tooltip!"
         assert [combo_box.itemText(i) for i in range(
@@ -1138,18 +1136,18 @@ class TestDataverseEditMetadataDialog:
         assert combo_box.currentText() == 'No Value', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
         assert clear_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame clear_button should be enabled!"
         assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog controlled_vocab_frame clear_button should have right tooltip!"
-        delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
+        delete_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
 
       # Set combo box items
       for i in range(5):
-        qtbot.keyClicks(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(i + 1).itemAt(0).widget(),
+        qtbot.keyClicks(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(i + 1).itemAt(0).widget(),
                         combo_box_items[i], delay=1)
 
       # Check if combo box items are updated in UI
-      for pos in range(1, edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count()):
-        combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        combo_box = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert combo_box.currentText() == combo_box_items[
           pos - 1], "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
 
@@ -1173,31 +1171,31 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with Life Sciences Metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Study Factor Type', delay=10)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Factor Type', "typesComboBox must be initialized with Study Factor Type option"
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 2 children!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 2 children!"
       combo_box_items = ['Age', 'Biomarkers', 'Cell Surface Markers', 'Developmental Stage']
 
       # Add new field items
       for _ in range(3):
-        qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton,
+        qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton,
                          Qt.LeftButton)
 
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
 
       # Set combo box items
       for i in range(4):
-        qtbot.keyClicks(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(i + 1).itemAt(0).widget(),
+        qtbot.keyClicks(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(i + 1).itemAt(0).widget(),
                         combo_box_items[i], delay=1)
-      for pos in range(1, edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count()):
-        combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        combo_box = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert combo_box.currentText() == combo_box_items[
           pos - 1], "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
 
       # Delete first two combo box items
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
                        Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
                        Qt.LeftButton)
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 3 children!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 3 children!"
 
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
     assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"

--- a/tests/component_tests/test_dataverse_edit_metadata_dialog.py
+++ b/tests/component_tests/test_dataverse_edit_metadata_dialog.py
@@ -11,7 +11,7 @@ from os import getcwd
 from os.path import dirname, join, realpath
 
 import pytest
-from PySide6.QtCore import QDate, QDateTime, Qt
+from PySide6.QtCore import QDate, Qt
 from PySide6.QtWidgets import QDialogButtonBox, QHBoxLayout, QVBoxLayout
 
 from pasta_eln.GUI.dataverse.edit_metadata_dialog import EditMetadataDialog
@@ -167,9 +167,9 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.licenseNameLineEdit.text() == "CC0 1.0", "licenseNameLineEdit must be initialized with default 'CC0 1.0' option"
       assert edit_metadata_dialog.licenseURLLineEdit.text() == "http://creativecommons.org/publicdomain/zero/1.0", "licenseURLLineEdit must be initialized with default 'http://creativecommons.org/publicdomain/zero/1.0' option"
       assert clear_button.text() == "Clear", "Clear button should have right text"
-      assert clear_button.toolTip() == 'Clear this particular vocabulary entry.', "Clear button should have right tooltip"
+      assert clear_button.toolTip() == 'Clear this particular entry.', "Clear button should have right tooltip"
       assert delete_button.text() == "Delete", "Delete button should have right text"
-      assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "Delete button should have right tooltip"
+      assert delete_button.toolTip() == 'Delete this particular entry.', "Delete button should have right tooltip"
       assert controlled_combo_box.toolTip() == 'Select the controlled vocabulary.', "controlled_combo_box should have right tooltip"
       controlled_combo_box_items = [controlled_combo_box.itemText(i) for i in range(controlled_combo_box.count())]
       assert controlled_combo_box_items == ['No Value', 'Agricultural Sciences', 'Business and Management',
@@ -296,8 +296,8 @@ class TestDataverseEditMetadataDialog:
                                'Resolution Redshift',
                                'Coverage Redshift Value'],
                               'Astro Type',
-                              ['Select the controlled vocabulary.', 'Clear this particular vocabulary entry.',
-                               'Delete this particular vocabulary entry.'], []),
+                              ['Select the controlled vocabulary.', 'Clear this particular entry.',
+                               'Delete this particular entry.'], []),
                              ("success_case_life_sciences_metadata", "Life Sciences Metadata", ['Study Design Type',
                                                                                                 'Study Factor Type',
                                                                                                 'Study Assay Organism',
@@ -308,8 +308,8 @@ class TestDataverseEditMetadataDialog:
                                                                                                 'Study Assay Platform',
                                                                                                 'Study Assay Cell Type'],
                               'Study Design Type',
-                              ['Select the controlled vocabulary.', 'Clear this particular vocabulary entry.',
-                               'Delete this particular vocabulary entry.'], []),
+                              ['Select the controlled vocabulary.', 'Clear this particular entry.',
+                               'Delete this particular entry.'], []),
                              ("success_case_journal_metadata", "Journal Metadata",
                               ['Journal Volume Issue', 'Journal Article Type'],
                               'Journal Volume Issue', ['Enter the Journal Volume value here. e.g. JournalVolume1',
@@ -718,7 +718,7 @@ class TestDataverseEditMetadataDialog:
         qtbot.keyClicks(vocab_combo, test_data[pos], delay=1)
         delete_button = vocab_horizontal_layouts[pos].itemAt(2).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog vocabHorizontalLayout delete_button should be enabled!"
-        assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "EditMetadataDialog vocabHorizontalLayout delete_button should have right tooltip!"
+        assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog vocabHorizontalLayout delete_button should have right tooltip!"
         assert vocab_combo.currentText() == test_data[
           pos], "EditMetadataDialog vocabHorizontalLayout combo_box should have right text!"
 
@@ -741,8 +741,65 @@ class TestDataverseEditMetadataDialog:
     qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
     assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
     assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['biomedical']['fields'][0][
-             'value'] == ['Cohort Study', 'Cross Sectional']
+             'value'].sort() == ['Cohort Study', 'Cross Sectional'].sort()
     mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
+
+  def test_clear_field_controlled_vocabulary_type_and_should_reset_to_no_value(self,
+                                                                               qtbot,
+                                                                               edit_metadata_dialog,
+                                                                               mock_database_api):
+    edit_metadata_dialog.show()
+    with qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500):
+      assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
+      qtbot.keyClicks(edit_metadata_dialog.metadataBlockComboBox, "Life Sciences Metadata", delay=1)
+      assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
+      assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Design Type', "typesComboBox must be initialized with 'Study Design Type' option"
+
+      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+
+      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "vocabHorizontalLayout")
+      assert vocab_horizontal_layouts, "EditMetadataDialog vocab_horizontal_layouts should be present!"
+      assert len(vocab_horizontal_layouts) == 1, "EditMetadataDialog vocab_horizontal_layouts should have 1 item!"
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "vocabHorizontalLayout")
+      assert len(
+        vocab_horizontal_layouts) == 4, "EditMetadataDialog vocab_horizontal_layouts should have 4 items!"
+      test_data = ["Case Control",
+                   "Cross Sectional",
+                   "Cohort Study",
+                   "Not Specified"]
+      for pos in range(len(vocab_horizontal_layouts)):
+        vocab_combo = vocab_horizontal_layouts[pos].itemAt(0).widget()
+        assert vocab_combo.isEnabled(), "EditMetadataDialog vocabHorizontalLayout combo_box should be enabled!"
+        assert vocab_combo.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog vocabHorizontalLayout combo_box should have right tooltip!"
+        qtbot.keyClicks(vocab_combo, test_data[pos], delay=1)
+        delete_button = vocab_horizontal_layouts[pos].itemAt(2).widget()
+        assert delete_button.isEnabled(), "EditMetadataDialog vocabHorizontalLayout delete_button should be enabled!"
+        assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog vocabHorizontalLayout delete_button should have right tooltip!"
+        assert vocab_combo.currentText() == test_data[
+          pos], "EditMetadataDialog vocabHorizontalLayout combo_box should have right text!"
+
+      # Clear two populated items
+      qtbot.mouseClick(vocab_horizontal_layouts[0].itemAt(1).widget(), Qt.LeftButton)
+      qtbot.mouseClick(vocab_horizontal_layouts[2].itemAt(1).widget(), Qt.LeftButton)
+
+      # Cleared items should be empty
+      test_data = ["No Value",
+                   "Cross Sectional",
+                   "No Value",
+                   "Not Specified"]
+      for pos in range(len(vocab_horizontal_layouts)):
+        vocab_combo = vocab_horizontal_layouts[pos].itemAt(0).widget()
+        assert vocab_combo.currentText() == test_data[
+          pos], "EditMetadataDialog vocabHorizontalLayout vocab_combo should be {test_data[pos]}!"
 
   def test_clear_field_compound_type_with_date_and_save_click_should_do_as_expected(self,
                                                                                     qtbot,
@@ -921,16 +978,11 @@ class TestDataverseEditMetadataDialog:
                                ("Description3", "2024-01-23"), ("Description4", "2024-01-23")],
                               [("Description1", "2024-01-01"), ("Description2", "2024-01-23"),
                                ("Description3", "2024-01-23"), ("Description4", "2024-01-23")]),
-                             ("success_case_multiple_data_with_none",
+                             ("success_case_multiple_data_with_none1",
                               [("Description1", None), (None, "2024-01-23"),
-                               ("", "2024-01-23"), ("Description4", "2024-01-23")],
-                              [("Description1", '2000-01-01'), ("", "2024-01-23"),
-                               ("", "2024-01-23"), ("Description4", "2024-01-23")]),
-                             ("success_case_multiple_data_with_none",
-                              [("", None), (None, ""),
-                               ("", ""), ("", "2024-01-23")],
-                              [("", '2000-01-01'), ("", "2000-01-01"),
-                               ("", "2000-01-01"), ("", "2024-01-23")]),
+                               ("", "2024-01-23"), ("Description4", "0001-01-23")],
+                              [("Description1", ''), ("", "2024-01-23"),
+                               ("", "2024-01-23"), ("Description4", "")]),
                            ])
   def test_add_field_compound_multiple_type_and_save_click_should_do_as_expected(self,
                                                                                  qtbot,
@@ -970,8 +1022,8 @@ class TestDataverseEditMetadataDialog:
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos - 1][0])
-        date_time_edit.setDateTime(QDateTime.fromString(test_data[pos - 1][1], 'yyyy-MM-dd'))
-
+        date_time_edit.setDate(QDate.fromString(test_data[pos - 1][1], 'yyyy-MM-dd'))
+        test = date_time_edit.text()
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
     assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
     qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
@@ -979,8 +1031,8 @@ class TestDataverseEditMetadataDialog:
     for pos in range(len(expected_data)):
       assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][7][
                'value'][pos]['dsDescriptionValue']['value'] == expected_data[pos][0]
-    assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][7][
-             'value'][pos]['dsDescriptionDate']['value'] == expected_data[pos][1]
+      assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][7][
+               'value'][pos]['dsDescriptionDate']['value'] == expected_data[pos][1]
     mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
 
   def test_delete_fields_compound_multiple_type_and_save_click_should_do_as_expected(self,
@@ -1013,18 +1065,21 @@ class TestDataverseEditMetadataDialog:
         assert line_edit.placeholderText() == 'Enter the Ds Description Value here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
         date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
-        assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
+        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
+        assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
+        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos - 1][0])
-        date_time_edit.setDateTime(QDateTime.fromString(test_data[pos - 1][1], 'yyyy-MM-dd'))
+        date_time_edit.setDate(QDate.fromString(test_data[pos - 1][1], 'yyyy-MM-dd'))
 
       # Delete two populated items
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
                        Qt.LeftButton)
       assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 4, "EditMetadataDialog primitive_vertical_layout should have 4 children!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
                        Qt.LeftButton)
       assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog primitive_vertical_layout should have 3 children!"
 
@@ -1053,37 +1108,42 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
       assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
       assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 2 children!"
-      combo_box_items = ['Age', 'Biomarkers', 'Cell Surface Markers', 'Developmental Stage']
+      combo_box_items = ['No Value', 'Age', 'Biomarkers', 'Cell Surface Markers', 'Developmental Stage']
       combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(0).widget()
       assert combo_box.isEnabled(), "EditMetadataDialog controlled_vocab_frame combo_box should be enabled!"
       assert combo_box.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog controlled_vocab_frame combo_box should have right tooltip!"
       assert [combo_box.itemText(i) for i in range(
         combo_box.count())] == combo_box_items, "EditMetadataDialog controlled_vocab_frame combo_box should have right options!"
-      assert combo_box.currentText() == 'Age', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
-      delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget()
+      assert combo_box.currentText() == 'No Value', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
+      clear_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget()
+      assert clear_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame clear_button should be enabled!"
+      assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog controlled_vocab_frame clear_button should have right tooltip!"
+      delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
       assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete_button should be enabled!"
-      assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
+      assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
 
       # Add new field items
-      for _ in range(3):
+      for _ in range(4):
         qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton,
                          Qt.LeftButton)
 
       # Check if the new field items are added in UI
-      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
+      assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 6, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 5 children!"
       for pos in range(1, edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count()):
         combo_box = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert combo_box.isEnabled(), "EditMetadataDialog controlled_vocab_frame combo_box should be enabled!"
         assert combo_box.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog controlled_vocab_frame combo_box should have right tooltip!"
         assert [combo_box.itemText(i) for i in range(
           combo_box.count())] == combo_box_items, "EditMetadataDialog controlled_vocab_frame combo_box should have right options!"
-        assert combo_box.currentText() == 'Age', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
-        delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
+        assert combo_box.currentText() == 'No Value', "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
+        assert clear_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame clear_button should be enabled!"
+        assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog controlled_vocab_frame clear_button should have right tooltip!"
+        delete_button = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete_button should be enabled!"
-        assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
+        assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog controlled_vocab_frame delete_button should have right tooltip!"
 
       # Set combo box items
-      for i in range(4):
+      for i in range(5):
         qtbot.keyClicks(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(i + 1).itemAt(0).widget(),
                         combo_box_items[i], delay=1)
 
@@ -1099,6 +1159,8 @@ class TestDataverseEditMetadataDialog:
     assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
     value = edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['biomedical']['fields'][1]['value']
     value.sort()
+    combo_box_items.remove('No Value')
+    combo_box_items.sort()
     assert value == combo_box_items, "EditMetadataDialog field value should be updated!"
     mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
 
@@ -1131,9 +1193,9 @@ class TestDataverseEditMetadataDialog:
           pos - 1], "EditMetadataDialog controlled_vocab_frame combo_box should have right default value!"
 
       # Delete first two combo box items
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
                        Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(1).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.itemAt(1).itemAt(2).widget(),
                        Qt.LeftButton)
       assert edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog controlled_vocab_frame mainVerticalLayout should contain 3 children!"
 
@@ -1264,10 +1326,13 @@ class TestDataverseEditMetadataDialog:
           1], "EditMetadataDialog primitive_compound_frame journal_issue_line_edit should have right text!"
         date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
-        assert date_time_edit.toolTip() == 'Enter the Journal Pub Date value here. e.g. 1008-01-01', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
+        assert date_time_edit.toolTip() == 'Enter the Journal Pub Date value here. e.g. 1008-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
         assert date_time_edit.date().toString("yyyy-MM-dd") == journal_volume_test_data[pos - 1][
           2], "EditMetadataDialog primitive_compound_frame date_time_edit should have right text!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
+        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
+        assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
+        assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
+        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(4).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Cancel), Qt.LeftButton)

--- a/tests/component_tests/test_dataverse_edit_metadata_dialog.py
+++ b/tests/component_tests/test_dataverse_edit_metadata_dialog.py
@@ -65,9 +65,9 @@ class TestDataverseEditMetadataDialog:
         QDialogButtonBox.Save).isVisible(), "EditMetadataDialog Save button should be shown!"
       assert edit_metadata_dialog.buttonBox.button(
         QDialogButtonBox.Cancel).isVisible(), "EditMetadataDialog Cancel button should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      primitive_vertical_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      primitive_vertical_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QVBoxLayout,
         "primitiveVerticalLayout")
       assert primitive_vertical_layout, "EditMetadataDialog primitive_compound_frame should be present!"
@@ -77,7 +77,7 @@ class TestDataverseEditMetadataDialog:
       delete_button = primitive_vertical_layout.itemAt(0).itemAt(2).widget()
       assert delete_button.isVisible(), "EditMetadataDialog primitive_compound_frame delete button should be shown!"
       assert not delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete button should be disabled!"
-      assert not edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be disabled!"
+      assert not edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be disabled!"
 
       assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with default 'Citation Metadata' option"
@@ -345,9 +345,9 @@ class TestDataverseEditMetadataDialog:
       assert meta_field_items == expected_fields, "typesComboBox should have right contents"
       assert edit_metadata_dialog.typesComboBox.currentText() == selected_field, f"typesComboBox must be initialized with default '{selected_field}' option"
       if test_id == "success_case_select_geospatial_metadata":
-        assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-        compound_Horizontal_Layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+        assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+        compound_Horizontal_Layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
           QHBoxLayout,
           "compoundHorizontalLayout")
         assert compound_Horizontal_Layout, "EditMetadataDialog compound_Horizontal_Layout should be present!"
@@ -361,12 +361,12 @@ class TestDataverseEditMetadataDialog:
             assert widget.placeholderText() == placeholderTexts[
               i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
         assert widget.text() == "Delete", "EditMetadataDialog compound_Horizontal_Layout widget should have right text!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog compound_Horizontal_Layout addPushButton should be disabled!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog compound_Horizontal_Layout addPushButton should be disabled!"
       elif test_id == "success_case_select_citation_metadata":
-        assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-        assert not edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
-        primitive_horizontal_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+        assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+        assert not edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
+        primitive_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
           QHBoxLayout,
           "primitiveHorizontalLayout")
         for i in range(primitive_horizontal_layout.count()):
@@ -380,10 +380,10 @@ class TestDataverseEditMetadataDialog:
             assert widget.placeholderText() == placeholderTexts[
               i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
       elif test_id == "success_case_select_social_science_metadata":
-        assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
-        primitive_horizontal_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+        assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+        primitive_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
           QHBoxLayout,
           "primitiveHorizontalLayout")
         for i in range(primitive_horizontal_layout.count()):
@@ -416,10 +416,10 @@ class TestDataverseEditMetadataDialog:
               'Case Control', 'Cross Sectional', 'Cohort Study',
               'Not Specified'], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right contents!"
       elif test_id == "success_case_journal_metadata":
-        assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-        assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
-        primitive_horizontal_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+        assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+        assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+        primitive_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
           QHBoxLayout,
           "compoundHorizontalLayout")
         assert primitive_horizontal_layout, "EditMetadataDialog primitive_horizontal_layout should be present!"
@@ -442,10 +442,10 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Origin Of Sources', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == "Origin Of Sources", "typesComboBox must be initialized with Origin Of Sources option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert not edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
-      primitive_horizontal_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert not edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
+      primitive_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QHBoxLayout,
         "primitiveHorizontalLayout")
       assert primitive_horizontal_layout, "EditMetadataDialog primitive_horizontal_layout should be present!"
@@ -494,18 +494,18 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Kind Of Data', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Kind Of Data', "typesComboBox must be initialized with 'Kind Of Data' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      primitive_vertical_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+      primitive_vertical_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QVBoxLayout,
         "primitiveVerticalLayout")
       assert primitive_vertical_layout, "EditMetadataDialog primitive_vertical_layout should be present!"
       assert primitive_vertical_layout.count() == 1, "EditMetadataDialog primitive_vertical_layout should have 1 child!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
       assert primitive_vertical_layout.count() == 4, "EditMetadataDialog primitive_vertical_layout should have 4 children!"
       for pos in range(primitive_vertical_layout.count()):
         line_edit = primitive_vertical_layout.itemAt(pos).itemAt(0).widget()
@@ -541,18 +541,18 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Kind Of Data', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Kind Of Data', "typesComboBox must be initialized with 'Kind Of Data' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      primitive_vertical_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+      primitive_vertical_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QVBoxLayout,
         "primitiveVerticalLayout")
       assert primitive_vertical_layout, "EditMetadataDialog primitive_vertical_layout should be present!"
       assert primitive_vertical_layout.count() == 1, "EditMetadataDialog primitive_vertical_layout should have 1 child!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
       assert primitive_vertical_layout.count() == 4, "EditMetadataDialog primitive_vertical_layout should have 4 children!"
       test_data = ["KindOfData1", "KindOfData2", "KindOfData3", "KindOfData4"]
       for pos in range(primitive_vertical_layout.count()):
@@ -589,19 +589,19 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Topic Classification', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Topic Classification', "typesComboBox must be initialized with 'Topic Classification' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+      compound_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "compoundHorizontalLayout")
       assert compound_horizontal_layouts, "EditMetadataDialog compoundHorizontalLayout should be present!"
       assert len(compound_horizontal_layouts) == 1, "EditMetadataDialog compound_horizontal_layouts should have 1 item!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      compound_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "compoundHorizontalLayout")
       assert len(
@@ -813,19 +813,19 @@ class TestDataverseEditMetadataDialog:
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, "Time Period Covered", delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Time Period Covered', "typesComboBox must be initialized with 'Time Period Covered' option"
 
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+      compound_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "compoundHorizontalLayout")
       assert compound_horizontal_layouts, "EditMetadataDialog compound_horizontal_layouts should be present!"
       assert len(compound_horizontal_layouts) == 1, "EditMetadataDialog compound_horizontal_layouts should have 1 item!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      compound_horizontal_layouts = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChildren(
         QHBoxLayout,
         "compoundHorizontalLayout")
       assert len(
@@ -936,11 +936,11 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Social Science and Humanities Metadata", "metadataBlockComboBox must be initialized with  Social Science and Humanities Metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Target Sample Size', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Target Sample Size', "typesComboBox must be initialized with 'Target Sample Size' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert not edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert not edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should not be enabled!"
 
-      compound_horizontal_layout = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChild(
+      compound_horizontal_layout = edit_metadata_dialog.metadata_frame.mainVerticalLayout.findChild(
         QHBoxLayout,
         "compoundHorizontalLayout")
       assert compound_horizontal_layout, "EditMetadataDialog compound_horizontal_layout should be present!"
@@ -998,27 +998,27 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Ds Description', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Ds Description', "typesComboBox must be initialized with 'Ds Description' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog primitive_vertical_layout should have 2 children!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
-      for pos in range(1, edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count()):
-        line_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog primitive_vertical_layout should have 2 children!"
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        line_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert line_edit.toolTip() == 'Enter the Ds Description Value value here. e.g. DescriptionText1', "EditMetadataDialog primitive_compound_frame line_edit should have right tooltip!"
         assert line_edit.placeholderText() == 'Enter the Ds Description Value here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
-        date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
+        date_time_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
-        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        clear_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
         assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
         assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
+        delete_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos - 1][0])
@@ -1049,39 +1049,39 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Ds Description', delay=1)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Ds Description', "typesComboBox must be initialized with 'Ds Description' option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
 
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog primitive_vertical_layout should have 2 children!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 2, "EditMetadataDialog primitive_vertical_layout should have 2 children!"
       # Add three entries
       for _ in range(3):
-        qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
-      for pos in range(1, edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count()):
-        line_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
+        qtbot.mouseClick(edit_metadata_dialog.metadata_frame.addPushButton, Qt.LeftButton)
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        line_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(0).widget()
         assert line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert line_edit.toolTip() == 'Enter the Ds Description Value value here. e.g. DescriptionText1', "EditMetadataDialog primitive_compound_frame line_edit should have right tooltip!"
         assert line_edit.placeholderText() == 'Enter the Ds Description Value here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
-        date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
+        date_time_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
-        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        clear_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
         assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
         assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
+        delete_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos - 1][0])
         date_time_edit.setDate(QDate.fromString(test_data[pos - 1][1], 'yyyy-MM-dd'))
 
       # Delete two populated items
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
                        Qt.LeftButton)
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 4, "EditMetadataDialog primitive_vertical_layout should have 4 children!"
-      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 4, "EditMetadataDialog primitive_vertical_layout should have 4 children!"
+      qtbot.mouseClick(edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(1).itemAt(3).widget(),
                        Qt.LeftButton)
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog primitive_vertical_layout should have 3 children!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 3, "EditMetadataDialog primitive_vertical_layout should have 3 children!"
 
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
     assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
@@ -1103,7 +1103,7 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with Life Sciences Metadata option"
       qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Study Factor Type', delay=10)
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Factor Type', "typesComboBox must be initialized with Study Factor Type option"
-      assert not edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should not be shown!"
+      assert not edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should not be shown!"
       assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
       assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
       assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
@@ -1305,34 +1305,34 @@ class TestDataverseEditMetadataDialog:
       qtbot.keyClicks(edit_metadata_dialog.metadataBlockComboBox, "Journal Metadata", delay=1)
       assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Journal Metadata", "metadataBlockComboBox must be initialized with Journal Metadata option"
       assert edit_metadata_dialog.typesComboBox.currentText() == 'Journal Volume Issue', "typesComboBox must be initialized with Journal Volume Issue option"
-      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
-      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
-      assert edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
-      for pos in range(1, edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.count()):
-        journal_volume_line_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(
+      assert edit_metadata_dialog.metadata_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.metadata_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+      assert edit_metadata_dialog.metadata_frame.mainVerticalLayout.count() == 5, "EditMetadataDialog primitive_vertical_layout should have 5 children!"
+      for pos in range(1, edit_metadata_dialog.metadata_frame.mainVerticalLayout.count()):
+        journal_volume_line_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(
           0).widget()
         assert journal_volume_line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert journal_volume_line_edit.toolTip() == 'Enter the Journal Volume value here. e.g. JournalVolume1', "EditMetadataDialog primitive_compound_frame journal_volume_line_edit should have right tooltip!"
         assert journal_volume_line_edit.placeholderText() == 'Enter the Journal Volume here.', "EditMetadataDialog primitive_compound_frame journal_volume_line_edit should have right placeholderText!"
         assert journal_volume_line_edit.text() == journal_volume_test_data[pos - 1][
           0], "EditMetadataDialog primitive_compound_frame journal_volume_line_edit should have right text!"
-        journal_issue_line_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(
+        journal_issue_line_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(
           1).widget()
         assert journal_issue_line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame journal_issue_line_edit should be enabled!"
         assert journal_issue_line_edit.toolTip() == 'Enter the Journal Issue value here. e.g. JournalIssue1', "EditMetadataDialog primitive_compound_frame journal_issue_line_edit should have right tooltip!"
         assert journal_issue_line_edit.placeholderText() == 'Enter the Journal Issue here.', "EditMetadataDialog primitive_compound_frame journal_issue_line_edit should have right placeholderText!"
         assert journal_issue_line_edit.text() == journal_volume_test_data[pos - 1][
           1], "EditMetadataDialog primitive_compound_frame journal_issue_line_edit should have right text!"
-        date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        date_time_edit = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert date_time_edit.toolTip() == 'Enter the Journal Pub Date value here. e.g. 1008-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
         assert date_time_edit.date().toString("yyyy-MM-dd") == journal_volume_test_data[pos - 1][
           2], "EditMetadataDialog primitive_compound_frame date_time_edit should have right text!"
-        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
+        clear_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
         assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
         assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(4).widget()
+        delete_button = edit_metadata_dialog.metadata_frame.mainVerticalLayout.itemAt(pos).itemAt(4).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Cancel), Qt.LeftButton)

--- a/tests/component_tests/test_dataverse_edit_metadata_dialog.py
+++ b/tests/component_tests/test_dataverse_edit_metadata_dialog.py
@@ -11,7 +11,7 @@ from os import getcwd
 from os.path import dirname, join, realpath
 
 import pytest
-from PySide6.QtCore import QDateTime, Qt
+from PySide6.QtCore import QDate, QDateTime, Qt
 from PySide6.QtWidgets import QDialogButtonBox, QHBoxLayout, QVBoxLayout
 
 from pasta_eln.GUI.dataverse.edit_metadata_dialog import EditMetadataDialog
@@ -71,7 +71,10 @@ class TestDataverseEditMetadataDialog:
         QVBoxLayout,
         "primitiveVerticalLayout")
       assert primitive_vertical_layout, "EditMetadataDialog primitive_compound_frame should be present!"
-      delete_button = primitive_vertical_layout.itemAt(0).itemAt(1).widget()
+      clear_button = primitive_vertical_layout.itemAt(0).itemAt(1).widget()
+      assert clear_button.isVisible(), "EditMetadataDialog primitive_compound_frame clear button should be shown!"
+      assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear button should be enabled!"
+      delete_button = primitive_vertical_layout.itemAt(0).itemAt(2).widget()
       assert delete_button.isVisible(), "EditMetadataDialog primitive_compound_frame delete button should be shown!"
       assert not delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete button should be disabled!"
       assert not edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be disabled!"
@@ -151,7 +154,10 @@ class TestDataverseEditMetadataDialog:
       controlled_combo_box = vocab_horizontal_layout.itemAt(0).widget()
       assert controlled_combo_box.isVisible(), "EditMetadataDialog controlled_vocab_frame controlled_combo_box should be shown!"
       assert controlled_combo_box.isEnabled(), "EditMetadataDialog controlled_vocab_frame controlled_combo_box should be enabled!"
-      delete_button = vocab_horizontal_layout.itemAt(1).widget()
+      clear_button = vocab_horizontal_layout.itemAt(1).widget()
+      assert clear_button.isVisible(), "EditMetadataDialog primitive_compound_frame clear button should be shown!"
+      assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear button should be enabled!"
+      delete_button = vocab_horizontal_layout.itemAt(2).widget()
       assert delete_button.isVisible(), "EditMetadataDialog controlled_vocab_frame delete button should be shown!"
       assert delete_button.isEnabled(), "EditMetadataDialog controlled_vocab_frame delete button should be enabled!"
       assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
@@ -160,14 +166,16 @@ class TestDataverseEditMetadataDialog:
       assert edit_metadata_dialog.typesComboBox.currentText() == "Subject", "typesComboBox must be initialized with default 'Title' option"
       assert edit_metadata_dialog.licenseNameLineEdit.text() == "CC0 1.0", "licenseNameLineEdit must be initialized with default 'CC0 1.0' option"
       assert edit_metadata_dialog.licenseURLLineEdit.text() == "http://creativecommons.org/publicdomain/zero/1.0", "licenseURLLineEdit must be initialized with default 'http://creativecommons.org/publicdomain/zero/1.0' option"
+      assert clear_button.text() == "Clear", "Clear button should have right text"
+      assert clear_button.toolTip() == 'Clear this particular vocabulary entry.', "Clear button should have right tooltip"
       assert delete_button.text() == "Delete", "Delete button should have right text"
       assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "Delete button should have right tooltip"
       assert controlled_combo_box.toolTip() == 'Select the controlled vocabulary.', "controlled_combo_box should have right tooltip"
       controlled_combo_box_items = [controlled_combo_box.itemText(i) for i in range(controlled_combo_box.count())]
-      assert controlled_combo_box_items == ['Agricultural Sciences', 'Business and Management', 'Engineering',
-                                            'Law'], "controlled_combo_box should have right contents"
+      assert controlled_combo_box_items == ['No Value', 'Agricultural Sciences', 'Business and Management',
+                                            'Engineering', 'Law'], "controlled_combo_box should have right contents"
       assert controlled_combo_box.toolTip() == 'Select the controlled vocabulary.', "controlled_combo_box should have right tooltip"
-      assert controlled_combo_box.currentText() == "Agricultural Sciences", "controlled_combo_box must be selected to 'Agricultural Sciences'"
+      assert controlled_combo_box.currentText() == "No Value", "controlled_combo_box must be selected to 'No Value'"
       meta_field_items = [edit_metadata_dialog.typesComboBox.itemText(i) for i in
                           range(edit_metadata_dialog.typesComboBox.count())]
       assert meta_field_items == ['Subject', 'Author', 'Dataset contact',
@@ -216,6 +224,7 @@ class TestDataverseEditMetadataDialog:
                                                                                              'Access To Sources'],
                               'Title',
                               ['Enter the Title value here. e.g. Replication Data for: Title',
+                               'Clear this particular entry.',
                                'Delete this particular entry.'], [
                                 'Enter the Title here.'
                               ]),
@@ -226,11 +235,13 @@ class TestDataverseEditMetadataDialog:
                                'Enter the State value here. e.g. GeographicCoverageStateProvince1',
                                'Enter the City value here. e.g. GeographicCoverageCity1',
                                'Enter the Other Geographic Coverage value here. e.g. GeographicCoverageOther1',
+                               'Clear this particular entry.',
                                'Delete this particular entry.'],
                               ['Enter the Country here.',
                                'Enter the State here.',
                                'Enter the City here.',
                                'Enter the Other Geographic Coverage here.',
+                               'Clear this particular entry.',
                                'Delete this particular entry.']),
                              ("success_case_select_social_science_metadata", "Social Science and Humanities Metadata", [
                                'Unit Of Analysis',
@@ -256,9 +267,11 @@ class TestDataverseEditMetadataDialog:
                                'Social Science Notes',
                              ], 'Unit Of Analysis', [
                                 'Enter the Unit Of Analysis value here. e.g. UnitOfAnalysis1',
+                                'Clear this particular entry.',
                                 'Delete this particular entry.'
                               ], [
                                 'Enter the Unit Of Analysis here.',
+                                'Clear this particular entry.',
                                 'Delete this particular entry.'
                               ]),
                              ("success_case_select_astronomy_metadata", "Astronomy and Astrophysics Metadata",
@@ -283,7 +296,8 @@ class TestDataverseEditMetadataDialog:
                                'Resolution Redshift',
                                'Coverage Redshift Value'],
                               'Astro Type',
-                              ['Select the controlled vocabulary.', 'Delete this particular vocabulary entry.'], []),
+                              ['Select the controlled vocabulary.', 'Clear this particular vocabulary entry.',
+                               'Delete this particular vocabulary entry.'], []),
                              ("success_case_life_sciences_metadata", "Life Sciences Metadata", ['Study Design Type',
                                                                                                 'Study Factor Type',
                                                                                                 'Study Assay Organism',
@@ -294,14 +308,17 @@ class TestDataverseEditMetadataDialog:
                                                                                                 'Study Assay Platform',
                                                                                                 'Study Assay Cell Type'],
                               'Study Design Type',
-                              ['Select the controlled vocabulary.', 'Delete this particular vocabulary entry.'], []),
+                              ['Select the controlled vocabulary.', 'Clear this particular vocabulary entry.',
+                               'Delete this particular vocabulary entry.'], []),
                              ("success_case_journal_metadata", "Journal Metadata",
                               ['Journal Volume Issue', 'Journal Article Type'],
                               'Journal Volume Issue', ['Enter the Journal Volume value here. e.g. JournalVolume1',
                                                        'Enter the Journal Issue value here. e.g. JournalIssue1',
-                                                       'Enter the Journal Pub Date value here. e.g. 1008-01-01',
+                                                       'Enter the Journal Pub Date value here. e.g. 1008-01-01, Minimum possible date is 0100-01-02',
+                                                       'Clear this particular entry.',
                                                        'Delete this particular entry.'],
                               ['Enter the Journal Volume here.', 'Enter the Journal Issue here.',
+                               'Clear this particular entry.',
                                'Delete this particular entry.']),
                            ])
   def test_change_metadata_block_to_different_selection_should_update_the_ui_correctly(self, qtbot,
@@ -313,7 +330,7 @@ class TestDataverseEditMetadataDialog:
                                                                                        tooltips,
                                                                                        placeholderTexts):
     edit_metadata_dialog.show()
-    with qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500):
+    with (qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500)):
       assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
       assert edit_metadata_dialog.metadataBlockComboBox.isVisible(), "EditMetadataDialog metadataBlockComboBox should be shown!"
 
@@ -339,10 +356,10 @@ class TestDataverseEditMetadataDialog:
           assert widget.isEnabled(), f"EditMetadataDialog compound_Horizontal_Layout {widget.objectName()} should be enabled!"
           assert widget.isVisible(), f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should be shown!"
           assert widget.toolTip() == tooltips[
-            i], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right tooltip!"
+            i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right tooltip!"
           if widget.objectName().lower().endswith("lineedit"):
             assert widget.placeholderText() == placeholderTexts[
-              i], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right placeholderText!"
+              i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
         assert widget.text() == "Delete", "EditMetadataDialog compound_Horizontal_Layout widget should have right text!"
         assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog compound_Horizontal_Layout addPushButton should be disabled!"
       elif test_id == "success_case_select_citation_metadata":
@@ -354,14 +371,14 @@ class TestDataverseEditMetadataDialog:
           "primitiveHorizontalLayout")
         for i in range(primitive_horizontal_layout.count()):
           widget = primitive_horizontal_layout.itemAt(i).widget()
-          assert not widget.isEnabled() if widget.objectName().lower().endswith(
-            "button") else widget.isEnabled(), f"EditMetadataDialog primitive_horizontal_layout {widget.objectName()} should not be enabled!"
+          assert not widget.isEnabled() if 'delete' in widget.objectName().lower(
+          ) else widget.isEnabled(), f"EditMetadataDialog primitive_horizontal_layout {widget.objectName()} should not be enabled!"
           assert widget.isVisible(), f"EditMetadataDialog primitive_horizontal_layout {widget.objectName()} should be shown!"
           assert widget.toolTip() == tooltips[
             i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right tooltip!"
           if widget.objectName().lower().endswith("lineedit"):
             assert widget.placeholderText() == placeholderTexts[
-              i], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right placeholderText!"
+              i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
       elif test_id == "success_case_select_social_science_metadata":
         assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
         assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
@@ -377,7 +394,7 @@ class TestDataverseEditMetadataDialog:
             i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right tooltip!"
           if widget.objectName().lower().endswith("lineedit"):
             assert widget.placeholderText() == placeholderTexts[
-              i], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right placeholderText!"
+              i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
       elif test_id == "success_case_select_astronomy_metadata" or test_id == "success_case_life_sciences_metadata":
         assert edit_metadata_dialog.controlled_vocab_frame, "EditMetadataDialog controlled_vocab_frame should be present!"
         assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
@@ -394,10 +411,10 @@ class TestDataverseEditMetadataDialog:
             i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right tooltip!"
           if widget.objectName().lower().endswith("combobox"):
             assert [widget.itemText(i) for i in
-                    range(widget.count())] == ['Image', 'Mosaic', 'EventList',
+                    range(widget.count())] == ['No Value', 'Image', 'Mosaic', 'EventList',
                                                'Cube'] if test_id == "success_case_select_astronomy_metadata" else [
               'Case Control', 'Cross Sectional', 'Cohort Study',
-              'Not Specified'], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right contents!"
+              'Not Specified'], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right contents!"
       elif test_id == "success_case_journal_metadata":
         assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
         assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
@@ -414,7 +431,7 @@ class TestDataverseEditMetadataDialog:
             i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right tooltip!"
           if widget.objectName().lower().endswith("lineedit"):
             assert widget.placeholderText() == placeholderTexts[
-              i], f"EditMetadataDialog primitive_compound_frame {widget.getObjectName()} should have right placeholderText!"
+              i], f"EditMetadataDialog primitive_compound_frame {widget.objectName()} should have right placeholderText!"
 
   def test_add_field_primitive_single_type_and_save_click_should_do_as_expected(self, qtbot, edit_metadata_dialog,
                                                                                 mock_database_api):
@@ -437,11 +454,14 @@ class TestDataverseEditMetadataDialog:
       assert line_edit.isVisible(), "EditMetadataDialog primitive_compound_frame line_edit should be shown!"
       assert line_edit.toolTip() == 'Enter the Origin Of Sources value here. e.g. OriginOfSources', "EditMetadataDialog primitive_compound_frame line_edit should have right tooltip!"
       assert line_edit.placeholderText() == 'Enter the Origin Of Sources here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
-      delete_button = primitive_horizontal_layout.itemAt(1).widget()
+      clear_button = primitive_horizontal_layout.itemAt(1).widget()
+      assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
+      assert clear_button.isVisible(), "EditMetadataDialog primitive_compound_frame clear_button should be shown!"
+      assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
+      delete_button = primitive_horizontal_layout.itemAt(2).widget()
       assert not delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should not be enabled!"
       assert delete_button.isVisible(), "EditMetadataDialog primitive_compound_frame delete_button should be shown!"
       assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
-
       line_edit.setText("test data...")
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
     assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
@@ -492,7 +512,12 @@ class TestDataverseEditMetadataDialog:
         assert line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert line_edit.toolTip() == 'Enter the Kind Of Data value here. e.g. KindOfData1', "EditMetadataDialog primitive_compound_frame line_edit should have right tooltip!"
         assert line_edit.placeholderText() == 'Enter the Kind Of Data here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
-        delete_button = primitive_vertical_layout.itemAt(pos).itemAt(1).widget()
+        clear_button = primitive_vertical_layout.itemAt(pos).itemAt(1).widget()
+        assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
+        assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
+        line_edit.setText(test_data[pos])
+
+        delete_button = primitive_vertical_layout.itemAt(pos).itemAt(2).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos])
@@ -535,14 +560,14 @@ class TestDataverseEditMetadataDialog:
         assert line_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
         assert line_edit.toolTip() == 'Enter the Kind Of Data value here. e.g. KindOfData1', "EditMetadataDialog primitive_compound_frame line_edit should have right tooltip!"
         assert line_edit.placeholderText() == 'Enter the Kind Of Data here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
-        delete_button = primitive_vertical_layout.itemAt(pos).itemAt(1).widget()
+        delete_button = primitive_vertical_layout.itemAt(pos).itemAt(2).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos])
       # Delete two populated items
-      qtbot.mouseClick(primitive_vertical_layout.itemAt(1).itemAt(1).widget(), Qt.LeftButton)
+      qtbot.mouseClick(primitive_vertical_layout.itemAt(1).itemAt(2).widget(), Qt.LeftButton)
       assert primitive_vertical_layout.count() == 3, "EditMetadataDialog primitive_vertical_layout should have 3 children!"
-      qtbot.mouseClick(primitive_vertical_layout.itemAt(2).itemAt(1).widget(), Qt.LeftButton)
+      qtbot.mouseClick(primitive_vertical_layout.itemAt(2).itemAt(2).widget(), Qt.LeftButton)
       assert primitive_vertical_layout.count() == 2, "EditMetadataDialog primitive_vertical_layout should have 2 children!"
 
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
@@ -552,6 +577,296 @@ class TestDataverseEditMetadataDialog:
     assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][25][
              'value'] == ["KindOfData1", "KindOfData3"]
     mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
+
+  def test_clear_field_compound_type_and_save_click_should_do_as_expected(self,
+                                                                          qtbot,
+                                                                          edit_metadata_dialog,
+                                                                          mock_database_api):
+    edit_metadata_dialog.show()
+    with qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500):
+      assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
+      qtbot.keyClicks(edit_metadata_dialog.metadataBlockComboBox, "Citation Metadata", delay=1)
+      assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
+      qtbot.keyClicks(edit_metadata_dialog.typesComboBox, 'Topic Classification', delay=1)
+      assert edit_metadata_dialog.typesComboBox.currentText() == 'Topic Classification', "typesComboBox must be initialized with 'Topic Classification' option"
+      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+
+      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "compoundHorizontalLayout")
+      assert compound_horizontal_layouts, "EditMetadataDialog compoundHorizontalLayout should be present!"
+      assert len(compound_horizontal_layouts) == 1, "EditMetadataDialog compound_horizontal_layouts should have 1 item!"
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "compoundHorizontalLayout")
+      assert len(
+        compound_horizontal_layouts) == 4, "EditMetadataDialog compound_horizontal_layouts should have 4 items!"
+      test_data = [("Top Class Term 1", "Top Class Vocab 1", "Top Class Url 1"),
+                   ("Top Class Term 2", "Top Class Vocab 2", "Top Class Url 2"),
+                   ("Top Class Term 3", "Top Class Vocab 3", "Top Class Url 3"),
+                   ("Top Class Term 4", "Top Class Vocab 4", "Top Class Url 4"), ]
+      for pos in range(len(compound_horizontal_layouts)):
+        line_edit_term = compound_horizontal_layouts[pos].itemAt(0).widget()
+        assert line_edit_term.isEnabled(), "EditMetadataDialog compoundHorizontalLayout line_edit should be enabled!"
+        assert line_edit_term.toolTip() == 'Enter the Topic Class Value value here. e.g. Topic Classification Term1', "EditMetadataDialog compoundHorizontalLayout line_edit should have right tooltip!"
+        assert line_edit_term.placeholderText() == 'Enter the Topic Class Value here.', "EditMetadataDialog compoundHorizontalLayout line_edit should have right placeholderText!"
+        line_edit_vocab = compound_horizontal_layouts[pos].itemAt(1).widget()
+        assert line_edit_vocab.isEnabled(), "EditMetadataDialog compoundHorizontalLayout line_edit should be enabled!"
+        assert line_edit_vocab.toolTip() == 'Enter the Topic Class Vocab value here. e.g. Topic Classification Vocab1', "EditMetadataDialog compoundHorizontalLayout line_edit should have right tooltip!"
+        assert line_edit_vocab.placeholderText() == 'Enter the Topic Class Vocab here.', "EditMetadataDialog compoundHorizontalLayout line_edit should have right placeholderText!"
+        line_edit_term_url = compound_horizontal_layouts[pos].itemAt(2).widget()
+        assert line_edit_term_url.isEnabled(), "EditMetadataDialog compoundHorizontalLayout line_edit should be enabled!"
+        assert line_edit_term_url.toolTip() == 'Enter the Topic Class Vocab URI value here. e.g. https://TopicClassificationURL1.com', "EditMetadataDialog compoundHorizontalLayout line_edit should have right tooltip!"
+        assert line_edit_term_url.placeholderText() == 'Enter the Topic Class Vocab URI here.', "EditMetadataDialog compoundHorizontalLayout line_edit should have right placeholderText!"
+        delete_button = compound_horizontal_layouts[pos].itemAt(4).widget()
+        assert delete_button.isEnabled(), "EditMetadataDialog compoundHorizontalLayout delete_button should be enabled!"
+        assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog compoundHorizontalLayout delete_button should have right tooltip!"
+        line_edit_term.setText(test_data[pos][0])
+        line_edit_vocab.setText(test_data[pos][1])
+        line_edit_term_url.setText(test_data[pos][2])
+        assert line_edit_term.text() == test_data[pos][
+          0], "EditMetadataDialog compoundHorizontalLayout line_edit should have right text!"
+        assert line_edit_vocab.text() == test_data[pos][
+          1], "EditMetadataDialog compoundHorizontalLayout line_edit should have right text!"
+        assert line_edit_term_url.text() == test_data[pos][
+          2], "EditMetadataDialog compoundHorizontalLayout line_edit should have right text!"
+      # Clear two populated items
+      qtbot.mouseClick(compound_horizontal_layouts[0].itemAt(3).widget(), Qt.LeftButton)
+      qtbot.mouseClick(compound_horizontal_layouts[3].itemAt(3).widget(), Qt.LeftButton)
+
+      # Cleared items should be empty
+      for pos in [0, 3]:
+        line_edit_term = compound_horizontal_layouts[pos].itemAt(0).widget()
+        line_edit_vocab = compound_horizontal_layouts[pos].itemAt(1).widget()
+        line_edit_term_url = compound_horizontal_layouts[pos].itemAt(2).widget()
+        assert line_edit_term.text() == "", "EditMetadataDialog compoundHorizontalLayout line_edit should be empty!"
+        assert line_edit_vocab.text() == "", "EditMetadataDialog compoundHorizontalLayout line_edit should be empty!"
+        assert line_edit_term_url.text() == "", "EditMetadataDialog compoundHorizontalLayout line_edit should be empty!"
+
+    qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
+    assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
+    qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
+    assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
+    assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][10][
+             'value'] == [{'topicClassValue': {'multiple': False,
+                                               'typeClass': 'primitive',
+                                               'typeName': 'topicClassValue',
+                                               'value': 'Top Class Term 2'},
+                           'topicClassVocab': {'multiple': False,
+                                               'typeClass': 'primitive',
+                                               'typeName': 'topicClassVocab',
+                                               'value': 'Top Class Vocab 2'},
+                           'topicClassVocabURI': {'multiple': False,
+                                                  'typeClass': 'primitive',
+                                                  'typeName': 'topicClassVocabURI',
+                                                  'value': 'Top Class Url 2'}},
+                          {'topicClassValue': {'multiple': False,
+                                               'typeClass': 'primitive',
+                                               'typeName': 'topicClassValue',
+                                               'value': 'Top Class Term 3'},
+                           'topicClassVocab': {'multiple': False,
+                                               'typeClass': 'primitive',
+                                               'typeName': 'topicClassVocab',
+                                               'value': 'Top Class Vocab 3'},
+                           'topicClassVocabURI': {'multiple': False,
+                                                  'typeClass': 'primitive',
+                                                  'typeName': 'topicClassVocabURI',
+                                                  'value': 'Top Class Url 3'}}]
+    mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
+
+  def test_clear_field_controlled_vocabulary_type_and_save_click_should_do_as_expected(self,
+                                                                                       qtbot,
+                                                                                       edit_metadata_dialog,
+                                                                                       mock_database_api):
+    edit_metadata_dialog.show()
+    with qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500):
+      assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
+      qtbot.keyClicks(edit_metadata_dialog.metadataBlockComboBox, "Life Sciences Metadata", delay=1)
+      assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Life Sciences Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
+      assert edit_metadata_dialog.typesComboBox.currentText() == 'Study Design Type', "typesComboBox must be initialized with 'Study Design Type' option"
+
+      assert edit_metadata_dialog.controlled_vocab_frame.instance.isVisible(), "EditMetadataDialog controlled_vocab_frame should be shown!"
+      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isVisible(), "EditMetadataDialog controlled_vocab_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.controlled_vocab_frame.addPushButton.isEnabled(), "EditMetadataDialog controlled_vocab_frame addPushButton should be enabled!"
+
+      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "vocabHorizontalLayout")
+      assert vocab_horizontal_layouts, "EditMetadataDialog vocab_horizontal_layouts should be present!"
+      assert len(vocab_horizontal_layouts) == 1, "EditMetadataDialog vocab_horizontal_layouts should have 1 item!"
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.controlled_vocab_frame.addPushButton, Qt.LeftButton)
+      vocab_horizontal_layouts = edit_metadata_dialog.controlled_vocab_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "vocabHorizontalLayout")
+      assert len(
+        vocab_horizontal_layouts) == 4, "EditMetadataDialog vocab_horizontal_layouts should have 4 items!"
+      test_data = ["Case Control",
+                   "Cross Sectional",
+                   "Cohort Study",
+                   "Not Specified"]
+      for pos in range(len(vocab_horizontal_layouts)):
+        vocab_combo = vocab_horizontal_layouts[pos].itemAt(0).widget()
+        assert vocab_combo.isEnabled(), "EditMetadataDialog vocabHorizontalLayout combo_box should be enabled!"
+        assert vocab_combo.toolTip() == 'Select the controlled vocabulary.', "EditMetadataDialog vocabHorizontalLayout combo_box should have right tooltip!"
+        qtbot.keyClicks(vocab_combo, test_data[pos], delay=1)
+        delete_button = vocab_horizontal_layouts[pos].itemAt(2).widget()
+        assert delete_button.isEnabled(), "EditMetadataDialog vocabHorizontalLayout delete_button should be enabled!"
+        assert delete_button.toolTip() == 'Delete this particular vocabulary entry.', "EditMetadataDialog vocabHorizontalLayout delete_button should have right tooltip!"
+        assert vocab_combo.currentText() == test_data[
+          pos], "EditMetadataDialog vocabHorizontalLayout combo_box should have right text!"
+
+      # Clear two populated items
+      qtbot.mouseClick(vocab_horizontal_layouts[0].itemAt(1).widget(), Qt.LeftButton)
+      qtbot.mouseClick(vocab_horizontal_layouts[3].itemAt(1).widget(), Qt.LeftButton)
+
+      # Cleared items should be empty
+      test_data = ["No Value",
+                   "Cross Sectional",
+                   "Cohort Study",
+                   "No Value"]
+      for pos in range(len(vocab_horizontal_layouts)):
+        vocab_combo = vocab_horizontal_layouts[pos].itemAt(0).widget()
+        assert vocab_combo.currentText() == test_data[
+          pos], "EditMetadataDialog vocabHorizontalLayout vocab_combo should be {test_data[pos]}!"
+
+    qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
+    assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
+    qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
+    assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
+    assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['biomedical']['fields'][0][
+             'value'] == ['Cohort Study', 'Cross Sectional']
+    mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
+
+  def test_clear_field_compound_type_with_date_and_save_click_should_do_as_expected(self,
+                                                                                    qtbot,
+                                                                                    edit_metadata_dialog,
+                                                                                    mock_database_api):
+    edit_metadata_dialog.show()
+    with qtbot.waitExposed(edit_metadata_dialog.instance, timeout=500):
+      assert edit_metadata_dialog.minimalFullComboBox.currentText() == "Full", "minimalFullComboBox must be initialized with default full option"
+      qtbot.keyClicks(edit_metadata_dialog.metadataBlockComboBox, "Citation Metadata", delay=1)
+      assert edit_metadata_dialog.metadataBlockComboBox.currentText() == "Citation Metadata", "metadataBlockComboBox must be initialized with  citation metadata option"
+      qtbot.keyClicks(edit_metadata_dialog.typesComboBox, "Time Period Covered", delay=1)
+      assert edit_metadata_dialog.typesComboBox.currentText() == 'Time Period Covered', "typesComboBox must be initialized with 'Time Period Covered' option"
+
+      assert edit_metadata_dialog.primitive_compound_frame.instance.isVisible(), "EditMetadataDialog primitive_compound_frame should be shown!"
+      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isVisible(), "EditMetadataDialog primitive_compound_frame addPushButton should be shown!"
+      assert edit_metadata_dialog.primitive_compound_frame.addPushButton.isEnabled(), "EditMetadataDialog primitive_compound_frame addPushButton should be enabled!"
+
+      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "compoundHorizontalLayout")
+      assert compound_horizontal_layouts, "EditMetadataDialog compound_horizontal_layouts should be present!"
+      assert len(compound_horizontal_layouts) == 1, "EditMetadataDialog compound_horizontal_layouts should have 1 item!"
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      qtbot.mouseClick(edit_metadata_dialog.primitive_compound_frame.addPushButton, Qt.LeftButton)
+      compound_horizontal_layouts = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.findChildren(
+        QHBoxLayout,
+        "compoundHorizontalLayout")
+      assert len(
+        compound_horizontal_layouts) == 4, "EditMetadataDialog compound_horizontal_layouts should have 4 items!"
+      test_data = [("2019-01-01", "2020-01-01"),
+                   ("1972-12-01", "1998-11-23"),
+                   ("2013-01-01", "2015-07-22"),
+                   ("1771-06-01", "1874-01-01")]
+      for pos in range(len(compound_horizontal_layouts)):
+        date_time_start = compound_horizontal_layouts[pos].itemAt(0).widget()
+        assert date_time_start.isEnabled(), "EditMetadataDialog compound_horizontal_layout date_time_start should be enabled!"
+        assert date_time_start.toolTip() == 'Enter the Time Period Covered Start value here. e.g. 1005-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog compound_horizontal_layout date_time_start should have right tooltip!"
+        date_time_end = compound_horizontal_layouts[pos].itemAt(1).widget()
+        assert date_time_end.isEnabled(), "EditMetadataDialog compound_horizontal_layout date_time_end should be enabled!"
+        assert date_time_end.toolTip() == 'Enter the Time Period Covered End value here. e.g. 1005-01-02, Minimum possible date is 0100-01-02', "EditMetadataDialog compound_horizontal_layout date_time_end should have right tooltip!"
+        delete_button = compound_horizontal_layouts[pos].itemAt(3).widget()
+        assert delete_button.isEnabled(), "EditMetadataDialog vocabHorizontalLayout delete_button should be enabled!"
+        assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog vocabHorizontalLayout delete_button should have right tooltip!"
+        date_time_start.setDate(QDate.fromString(test_data[pos][0], 'yyyy-MM-dd'))
+        date_time_end.setDate(QDate.fromString(test_data[pos][1], 'yyyy-MM-dd'))
+        assert date_time_start.text() == test_data[pos][
+          0], f"EditMetadataDialog compound_horizontal_layout date_time_start should be {test_data[pos][0]}!"
+        assert date_time_end.text() == test_data[pos][
+          1], f"EditMetadataDialog compound_horizontal_layout date_time_end should be {test_data[pos][1]}!"
+
+      # Clear two populated items
+      qtbot.mouseClick(compound_horizontal_layouts[0].itemAt(2).widget(), Qt.LeftButton)
+      qtbot.mouseClick(compound_horizontal_layouts[3].itemAt(2).widget(), Qt.LeftButton)
+      # Cleared items should be empty
+      test_data = [("No Value", "No Value"),
+                   ("1972-12-01", "1998-11-23"),
+                   ("2013-01-01", "2015-07-22"),
+                   ("No Value", "No Value")]
+      for pos in range(len(compound_horizontal_layouts)):
+        date_time_start = compound_horizontal_layouts[pos].itemAt(0).widget()
+        date_time_end = compound_horizontal_layouts[pos].itemAt(1).widget()
+        assert date_time_start.text() == test_data[pos][
+          0], f"EditMetadataDialog compound_horizontal_layout date_time_start should be {test_data[pos][0]}!"
+        assert date_time_end.text() == test_data[pos][
+          1], f"EditMetadataDialog compound_horizontal_layout date_time_end should be {test_data[pos][1]}!"
+    # Click Save button and confirm the summary dialog to see if the expected changes are saved in metadata
+    qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
+    assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
+    qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
+    assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
+    assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][23][
+             'value'] == [{'timePeriodCoveredEnd': {'multiple': False,
+                                                    'typeClass': 'primitive',
+                                                    'typeName': 'timePeriodCoveredEnd',
+                                                    'value': '1998-11-23'},
+                           'timePeriodCoveredStart': {'multiple': False,
+                                                      'typeClass': 'primitive',
+                                                      'typeName': 'timePeriodCoveredStart',
+                                                      'value': '1972-12-01'}},
+                          {'timePeriodCoveredEnd': {'multiple': False,
+                                                    'typeClass': 'primitive',
+                                                    'typeName': 'timePeriodCoveredEnd',
+                                                    'value': '2015-07-22'},
+                           'timePeriodCoveredStart': {'multiple': False,
+                                                      'typeClass': 'primitive',
+                                                      'typeName': 'timePeriodCoveredStart',
+                                                      'value': '2013-01-01'}}]
+    mock_database_api.update_model_document.assert_called_once_with(edit_metadata_dialog.config_model)
+
+    # Clear start and end date of the two populated items
+    test_data = [("No Value", "No Value"),
+                 ("0001-12-01", "1998-11-23"),  # start date is below minimal date
+                 ("2013-01-01", "0100-01-01"),  # end date is below minimal date
+                 ("No Value", "No Value")]
+    for pos in range(len(compound_horizontal_layouts)):
+      date_time_start = compound_horizontal_layouts[pos].itemAt(0).widget()
+      date_time_end = compound_horizontal_layouts[pos].itemAt(1).widget()
+      date_time_start.setDate(QDate.fromString(test_data[pos][0], 'yyyy-MM-dd'))
+      date_time_end.setDate(QDate.fromString(test_data[pos][1], 'yyyy-MM-dd'))
+
+    # Click Save button and confirm the summary dialog to see if the expected changes are saved in metadata
+    qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Save), Qt.LeftButton)
+    assert edit_metadata_dialog.metadata_summary_dialog.instance.isVisible(), "EditMetadataDialogSummary should be visible!"
+    qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
+    assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
+    assert edit_metadata_dialog.metadata['datasetVersion']['metadataBlocks']['citation']['fields'][23][
+             'value'] == [{'timePeriodCoveredEnd': {'multiple': False,
+                                                    'typeClass': 'primitive',
+                                                    'typeName': 'timePeriodCoveredEnd',
+                                                    'value': '1998-11-23'},
+                           'timePeriodCoveredStart': {'multiple': False,
+                                                      'typeClass': 'primitive',
+                                                      'typeName': 'timePeriodCoveredStart',
+                                                      'value': ''}},
+                          {'timePeriodCoveredEnd': {'multiple': False,
+                                                    'typeClass': 'primitive',
+                                                    'typeName': 'timePeriodCoveredEnd',
+                                                    'value': ''},
+                           'timePeriodCoveredStart': {'multiple': False,
+                                                      'typeClass': 'primitive',
+                                                      'typeName': 'timePeriodCoveredStart',
+                                                      'value': '2013-01-01'}}]
+    mock_database_api.update_model_document.assert_any_call(edit_metadata_dialog.config_model)
 
   def test_add_field_compound_single_type_and_save_click_should_do_as_expected(self,
                                                                                qtbot,
@@ -580,7 +895,10 @@ class TestDataverseEditMetadataDialog:
       assert line_edit2.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
       assert line_edit2.toolTip() == 'Enter the Target Sample Size Formula value here. e.g. TargetSampleSizeFormula', "EditMetadataDialog compound_horizontal_layout line_edit should have right tooltip!"
       assert line_edit2.placeholderText() == 'Enter the Target Sample Size Formula here.', "EditMetadataDialog compound_horizontal_layout line_edit should have right placeholderText!"
-      delete_button = compound_horizontal_layout.itemAt(2).widget()
+      clear_button = compound_horizontal_layout.itemAt(2).widget()
+      assert clear_button.isEnabled(), "EditMetadataDialog compound_horizontal_layout clear_button should be enabled!"
+      assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog compound_horizontal_layout clear_button should have right tooltip!"
+      delete_button = compound_horizontal_layout.itemAt(3).widget()
       assert not delete_button.isEnabled(), "EditMetadataDialog compound_horizontal_layout delete_button should not be enabled!"
       assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog compound_horizontal_layout delete_button should have right tooltip!"
       line_edit1.setText("targetSampleSize")
@@ -644,8 +962,11 @@ class TestDataverseEditMetadataDialog:
         assert line_edit.placeholderText() == 'Enter the Ds Description Value here.', "EditMetadataDialog primitive_compound_frame line_edit should have right placeholderText!"
         date_time_edit = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(1).widget()
         assert date_time_edit.isEnabled(), "EditMetadataDialog primitive_compound_frame line_edit should be enabled!"
-        assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
-        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        assert date_time_edit.toolTip() == 'Enter the Ds Description Date value here. e.g. 1000-01-01, Minimum possible date is 0100-01-02', "EditMetadataDialog primitive_compound_frame date_time_edit should have right tooltip!"
+        clear_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(2).widget()
+        assert clear_button.isEnabled(), "EditMetadataDialog primitive_compound_frame clear_button should be enabled!"
+        assert clear_button.toolTip() == 'Clear this particular entry.', "EditMetadataDialog primitive_compound_frame clear_button should have right tooltip!"
+        delete_button = edit_metadata_dialog.primitive_compound_frame.mainVerticalLayout.itemAt(pos).itemAt(3).widget()
         assert delete_button.isEnabled(), "EditMetadataDialog primitive_compound_frame delete_button should be enabled!"
         assert delete_button.toolTip() == 'Delete this particular entry.', "EditMetadataDialog primitive_compound_frame delete_button should have right tooltip!"
         line_edit.setText(test_data[pos - 1][0])
@@ -997,17 +1318,17 @@ class TestDataverseEditMetadataDialog:
                                                                                           'Name: New License Name\n'
                                                                                           'URI: New License Url\n'
                                                                                           'Citation Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Geospatial Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Social Science and Humanities Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Astronomy and Astrophysics Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Life Sciences Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Journal Metadata:\n'
-                                                                                          'No value'), "EditMetadataDialogSummary should have right text!"
+                                                                                          'No Value'), "EditMetadataDialogSummary should have right text!"
     qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.Yes), Qt.LeftButton)
     assert not edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be closed!"
     assert edit_metadata_dialog.metadata['datasetVersion']['license'][
@@ -1030,17 +1351,17 @@ class TestDataverseEditMetadataDialog:
                                                                                           'Name: New License Name\n'
                                                                                           'URI: New License Url\n'
                                                                                           'Citation Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Geospatial Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Social Science and Humanities Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Astronomy and Astrophysics Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Life Sciences Metadata:\n'
-                                                                                          'No value\n'
+                                                                                          'No Value\n'
                                                                                           'Journal Metadata:\n'
-                                                                                          'No value'), "EditMetadataDialogSummary should have right text!"
+                                                                                          'No Value'), "EditMetadataDialogSummary should have right text!"
     qtbot.mouseClick(edit_metadata_dialog.metadata_summary_dialog.buttonBox.button(QDialogButtonBox.No), Qt.LeftButton)
     assert edit_metadata_dialog.instance.isVisible(), "EditMetadataDialog instance should be visible!"
     qtbot.mouseClick(edit_metadata_dialog.buttonBox.button(QDialogButtonBox.Cancel), Qt.LeftButton)

--- a/tests/unit_tests/test_data_hierarchy_terminology_lookup_service.py
+++ b/tests/unit_tests/test_data_hierarchy_terminology_lookup_service.py
@@ -315,7 +315,8 @@ class TestDataHierarchyTerminologyLookup(object):
       assert isinstance(iri_result['results'], list), "Results field in each iri_result must be a list"
       for item in iri_result['results']:
         assert isinstance(item, dict), "Each item in results must be a dictionary"
-        assert item['iri'] is not None and validate_url(item['iri']), "Each retrieved results must have a valid IRI"
+        assert item['iri'] is not None and (
+              'file:/' in item['iri'] or validate_url(item['iri'])), "Each retrieved results must have a valid IRI"
         assert item['information'] is not None, "Each retrieved results must have a valid information field"
 
 

--- a/tests/unit_tests/test_dataverse_compound_data_type_class.py
+++ b/tests/unit_tests/test_dataverse_compound_data_type_class.py
@@ -1,0 +1,429 @@
+""" Unit tests for the compound data type class. """
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_compound_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QBoxLayout, QDateTimeEdit, QFrame, QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout
+from _pytest.mark import param
+from mock.mock import call
+
+from pasta_eln.GUI.dataverse.compound_data_type_class import CompoundDataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+
+
+@pytest.fixture
+def mock_widget():
+  widget = MagicMock(spec=QLineEdit)
+  widget.objectName.return_value = "testLineEdit"
+  widget.text.return_value = "test_value"
+  return widget
+
+
+@pytest.fixture
+def mock_layout(mock_widget):
+  layout = MagicMock(spec=QBoxLayout)
+  layout.count.return_value = 1
+  layout.itemAt.return_value.widget.return_value = mock_widget
+  return layout
+
+
+@pytest.fixture
+def setup_context():
+  context = MagicMock(spec=DataTypeClassContext)
+  context.meta_field = {
+    'valueTemplate': [{'typeName': 'date', 'value': '2023-10-01'}, {'typeName': 'text', 'value': 'Sample Text'}]}
+  context.parent_frame = MagicMock(spec=QFrame)
+  context.add_push_button = MagicMock(spec=QPushButton)
+  context.main_vertical_layout = MagicMock(spec=QVBoxLayout)
+  return context
+
+
+@pytest.fixture
+def mock_compound_data_type_class(mocker, setup_context):
+  mocker.patch("pasta_eln.GUI.dataverse.compound_data_type_class.logging.getLogger")
+  return CompoundDataTypeClass(setup_context)
+
+
+class TestCompoundDataTypeClass:
+
+  def test_init_happy_path(self, mocker):
+    # Arrange
+    mock_base_class_init = mocker.patch("pasta_eln.GUI.dataverse.compound_data_type_class.DataTypeClass.__init__")
+    mock_context = mocker.MagicMock(spec=DataTypeClassContext)
+    mock_logger = mocker.patch("pasta_eln.GUI.dataverse.compound_data_type_class.logging.getLogger")
+
+    # Act
+    instance = CompoundDataTypeClass(mock_context)
+
+    # Assert
+    mock_base_class_init.assert_called_once_with(mock_context)
+    mock_logger.assert_called_once_with('pasta_eln.GUI.dataverse.compound_data_type_class.CompoundDataTypeClass')
+    assert instance.logger == mock_logger.return_value
+
+  @pytest.mark.parametrize("value_template, expected_widgets_added, expected_calls", [
+    # Success path with various realistic test values
+    ([
+       {
+         "journalVolume": {
+           "typeName": "journalVolume",
+           "multiple": False,
+           "typeClass": "primitive",
+           "value": "JournalVolume1"
+         },
+         "journalIssue": {
+           "typeName": "journalIssue",
+           "multiple": False,
+           "typeClass": "primitive",
+           "value": "JournalIssue1"
+         },
+         "journalPubDate": {
+           "typeName": "journalPubDate",
+           "multiple": False,
+           "typeClass": "primitive",
+           "value": "1008-01-01"
+         }
+       }
+     ], [QLineEdit, QLineEdit, QDateTimeEdit], 3),
+    # Edge case: empty valueTemplate
+    ([{}], [], 0),
+    # Edge case: valueTemplate with non-dict values
+    ([{'typeName': {'typeName': 'dateTime', 'value': '2023-10-10'}}, 'invalid'], [QDateTimeEdit], 1),
+    # Error case: valueTemplate with missing typeName
+    ([{'typeName': {'value': '2023-10-10'}}], [], 0),
+    # Error case: valueTemplate with missing value
+    ([{'typeName': 'dateTime'}], [], 0),
+  ], ids=["success_path", "empty_value_template", "non_dict_value", "missing_type_name", "missing_value"])
+  def test_add_new_entry_parametrized(self, mocker, mock_compound_data_type_class, value_template,
+                                      expected_widgets_added, expected_calls):
+    # Arrange
+    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.QHBoxLayout')
+    mock_add_clear_button = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.add_clear_button')
+    mock_add_delete_button = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.add_delete_button')
+    mock_create_line_edit = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.create_line_edit')
+    mock_create_date_time_widget = mocker.patch(
+      'pasta_eln.GUI.dataverse.compound_data_type_class.create_date_time_widget')
+    mock_is_date_time_type = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.is_date_time_type')
+    mock_is_date_time_type.side_effect = lambda x: x.lower() == 'dateTime' or 'date' in x.lower() or 'time' in x.lower()
+    mock_create_date_time_widget.return_value = MagicMock()
+    mock_create_line_edit.return_value = MagicMock()
+    mock_add_clear_button.return_value = None
+    mock_add_delete_button.return_value = None
+    mock_compound_data_type_class.context.meta_field = {'valueTemplate': value_template}
+
+    # Act
+    mock_compound_data_type_class.add_new_entry()
+
+    # Assert
+    assert mock_create_date_time_widget.call_count + mock_create_line_edit.call_count == expected_calls
+    assert mock_add_clear_button.called
+    assert mock_add_delete_button.called
+    if expected_calls > 0:
+      mock_qhbox_layout.return_value.addWidget.assert_has_calls(
+        [mocker.call(mock_create_line_edit.return_value) if w is QLineEdit else mocker.call(
+          mock_create_date_time_widget.return_value) for w in expected_widgets_added]
+      )
+      mock_compound_data_type_class.context.main_vertical_layout.addLayout.assert_called_once_with(
+        mock_qhbox_layout.return_value)
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_calls",
+    [
+      # Success path: single value, not multiple
+      param(
+        {'valueTemplate': {'key': 'template'}, 'value': {'key': 'value'}, 'multiple': False},
+        [call({'key': 'value'}, {'key': 'template'}, False)],
+        id="single_value_not_multiple"
+      ),
+      # Success path: multiple values, empty list
+      param(
+        {'valueTemplate': [{'key': 'template'}], 'value': [], 'multiple': True},
+        [call({'key': 'template'}, {'key': 'template'})],
+        id="multiple_values_empty_list"
+      ),
+      # Happy path: multiple values, non-empty list
+      param(
+        {'valueTemplate': [{'key': 'template'}], 'value': [{'key': 'value1'}, {'key': 'value2'}], 'multiple': True},
+        [call({'key': 'value1'}, {'key': 'template'}), call({'key': 'value2'}, {'key': 'template'})],
+        id="multiple_values_non_empty_list"
+      ),
+      # Edge case: single value, no value provided
+      param(
+        {'valueTemplate': {'key': 'template'}, 'value': None, 'multiple': False},
+        [call({'key': 'template'}, {'key': 'template'}, False)],
+        id="single_value_no_value_provided"
+      ),
+      # Edge case: multiple values, no value template
+      param(
+        {'valueTemplate': None, 'value': [{'key': 'value1'}], 'multiple': True},
+        [],
+        id="multiple_values_no_value_template"
+      ),
+      # Error case: valueTemplate is not a list when multiple is True
+      param(
+        {'valueTemplate': {'key': 'template'}, 'value': [], 'multiple': True},
+        [],
+        id="value_template_not_list_multiple_true"
+      ),
+      # Error case: value is not a list when multiple is True
+      param(
+        {'valueTemplate': [{'key': 'template'}], 'value': {'key': 'value'}, 'multiple': True},
+        [],
+        id="value_not_list_multiple_true"
+      ),
+    ],
+    ids=lambda x: x[-1]
+  )
+  def test_populate_entry(self, mock_compound_data_type_class, meta_field, expected_calls):
+    # Arrange
+    mock_compound_data_type_class.populate_compound_entry = MagicMock()
+    mock_compound_data_type_class.context.meta_field = meta_field
+
+    # Act
+    mock_compound_data_type_class.populate_entry()
+
+    # Assert
+    assert mock_compound_data_type_class.context.add_push_button.setDisabled.called == (not meta_field['multiple'])
+    assert mock_compound_data_type_class.populate_compound_entry.call_args_list == expected_calls
+
+  @pytest.mark.parametrize(
+    "meta_field, layout_items, expected_value, log_error_called",
+    [
+      # Success path: multiple is True, with valueTemplate
+      (
+          {'multiple': True, 'value': [1, 2, 3], 'valueTemplate': [{'key': 'value'}]},
+          [MagicMock(spec=QHBoxLayout), MagicMock(spec=QHBoxLayout)],
+          [],
+          False
+      ),
+      # Success path: multiple is False, with valueTemplate
+      (
+          {'multiple': False, 'value': [1, 2, 3], 'valueTemplate': {'key': 'value'}},
+          [MagicMock(spec=QHBoxLayout)],
+          {},
+          False
+      ),
+      # Edge case: multiple is True, no valueTemplate
+      (
+          {'multiple': True, 'value': [1, 2, 3]},
+          [MagicMock(spec=QHBoxLayout)],
+          [],
+          False
+      ),
+      # Edge case: multiple is False, no valueTemplate
+      (
+          {'multiple': False, 'value': [1, 2, 3]},
+          [MagicMock(spec=QHBoxLayout)],
+          {},
+          False
+      ),
+      # Error case: multiple is False, compound horizontal layout not found
+      (
+          {'multiple': False, 'value': [1, 2, 3]},
+          [],
+          {},
+          True
+      ),
+    ],
+    ids=[
+      "multiple_true_with_valueTemplate",
+      "multiple_false_with_valueTemplate",
+      "multiple_true_no_valueTemplate",
+      "multiple_false_no_valueTemplate",
+      "multiple_false_layout_not_found",
+    ]
+  )
+  def test_save_modifications(self, mock_compound_data_type_class, meta_field, layout_items, expected_value,
+                              log_error_called):
+    # Arrange
+    main_vertical_layout = MagicMock(spec=QHBoxLayout)
+    if meta_field.get('multiple'):
+      main_vertical_layout.itemAt.side_effect = layout_items
+    else:
+      main_vertical_layout.findChild.return_value = layout_items[0] if layout_items else None
+
+    mock_compound_data_type_class.context.meta_field = meta_field
+    mock_compound_data_type_class.context.main_vertical_layout = main_vertical_layout
+
+    # Act
+    mock_compound_data_type_class.save_modifications()
+
+    # Assert
+    assert mock_compound_data_type_class.context.meta_field['value'] == expected_value
+    if log_error_called:
+      mock_compound_data_type_class.logger.error.assert_called_once_with("Compound horizontal layout not found")
+    else:
+      mock_compound_data_type_class.logger.error.assert_not_called()
+
+  @pytest.mark.parametrize(
+    "widget_text, expected_value, initial_meta_field, expected_meta_field",
+    [
+      ("test_value", "test_value", {}, {'test': {'value': 'test_value'}}),
+      ("No Value", "", {}, {}),
+      ("", "", {}, {}),
+      ("test_value", "test_value", {'test': {'value': 'initial_value'}}, {'test': {'value': 'test_value'}}),
+      ("test_value", "test_value", [], [{'test': {'value': 'test_value'}}]),
+    ],
+    ids=[
+      "normal_value",
+      "no_value",
+      "empty_value",
+      "overwrite_existing_value",
+      "append_to_list"
+    ]
+  )
+  def test_save_compound_horizontal_layout_values(self, mock_compound_data_type_class, mock_layout, widget_text,
+                                                  expected_value,
+                                                  initial_meta_field, expected_meta_field):
+    # Arrange
+    mock_compound_data_type_class.context.meta_field['value'] = initial_meta_field
+    mock_layout.itemAt.return_value.widget.return_value.text.return_value = widget_text
+    value_template = {'test': {'value': ''}}
+    mock_compound_data_type_class.context.meta_field['valueTemplate'] = value_template
+
+    # Act
+    mock_compound_data_type_class.save_compound_horizontal_layout_values(mock_layout, value_template)
+
+    # Assert
+    assert mock_compound_data_type_class.context.meta_field['value'] == expected_meta_field
+
+  @pytest.mark.parametrize(
+    "layout_count, initial_meta_field, expected_meta_field",
+    [
+      (0, {}, {}),
+      (0, [], []),
+    ],
+    ids=[
+      "empty_layout_dict",
+      "empty_layout_list"
+    ]
+  )
+  def test_save_compound_horizontal_layout_values_empty_layout(self, mock_compound_data_type_class, layout_count,
+                                                               initial_meta_field,
+                                                               expected_meta_field):
+    # Arrange
+    mock_compound_data_type_class.context.meta_field['value'] = initial_meta_field
+    mock_layout = MagicMock(spec=QBoxLayout)
+    mock_layout.count.return_value = layout_count
+    value_template = {'test': {'value': ''}}
+    mock_compound_data_type_class.context.meta_field['valueTemplate'] = value_template
+
+    # Act
+    mock_compound_data_type_class.save_compound_horizontal_layout_values(mock_layout, value_template)
+
+    # Assert
+    assert mock_compound_data_type_class.context.meta_field['value'] == expected_meta_field
+
+  @pytest.mark.parametrize(
+    "initial_meta_field, expected_meta_field",
+    [
+      ({'value': 'string_value'}, {'test': {'value': 'test_value'}, 'value': 'string_value'}),
+      (None, {'test': {'value': 'test_value'}}),
+    ],
+    ids=[
+      "initial_value_string",
+      "initial_value_none"
+    ]
+  )
+  def test_save_compound_horizontal_layout_values_non_dict_list_initial_value(self, mock_compound_data_type_class,
+                                                                              mock_layout,
+                                                                              initial_meta_field, expected_meta_field):
+    # Arrange
+    mock_compound_data_type_class.context.meta_field['value'] = initial_meta_field
+    mock_layout.itemAt.return_value.widget.return_value.text.return_value = "test_value"
+    value_template = {'test': {'value': ''}}
+    mock_compound_data_type_class.context.meta_field['valueTemplate'] = value_template
+
+    # Act
+    mock_compound_data_type_class.save_compound_horizontal_layout_values(mock_layout, value_template)
+
+    # Assert
+    assert mock_compound_data_type_class.context.meta_field['value'] == expected_meta_field
+
+  @pytest.mark.parametrize(
+    "compound_entry, template_entry, enable_delete_button, expected_widget_count",
+    [
+      # Success path test cases
+      pytest.param(
+        {"date": {"value": "2023-10-01T12:00:00"}},
+        {"date": {"value": "2023-10-01T12:00:00"}},
+        True,
+        3,
+        id="success_path_with_date"
+      ),
+      pytest.param(
+        {"text": {"value": "example"}},
+        {"text": {"value": "example"}},
+        True,
+        3,
+        id="success_path_with_text"
+      ),
+      # Edge cases
+      pytest.param(
+        {},
+        None,
+        True,
+        0,
+        id="empty_compound_entry"
+      ),
+      pytest.param(
+        {"date": {"value": "2023-10-01T12:00:00"}},
+        None,
+        False,
+        2,
+        id="no_template_entry"
+      ),
+      # Error cases
+      pytest.param(
+        {"date": {"value": "invalid-date"}},
+        None,
+        True,
+        2,
+        id="invalid_date_value"
+      ),
+      pytest.param(
+        {"unknown_type": {"value": "example"}},
+        None,
+        True,
+        2,
+        id="unknown_type"
+      ),
+    ]
+  )
+  def test_populate_compound_entry(self, mock_compound_data_type_class, mocker, compound_entry, template_entry,
+                                   enable_delete_button,
+                                   expected_widget_count):
+    # Arrange
+    mock_is_date_time_type = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.is_date_time_type',
+                                          lambda x: x == 'date')
+    mock_compound_create_date_time_widget = mocker.patch(
+      'pasta_eln.GUI.dataverse.compound_data_type_class.create_date_time_widget')
+    mock_create_line_edit = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.create_line_edit')
+    mock_add_delete_button = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.add_delete_button')
+    mock_add_clear_button = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.add_clear_button')
+    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.compound_data_type_class.QHBoxLayout')
+    mock_qhbox_layout.return_value.count.return_value = len(compound_entry)
+
+    # Act
+    mock_compound_data_type_class.populate_compound_entry(compound_entry, template_entry, enable_delete_button)
+
+    # Assert
+    mock_qhbox_layout.assert_called_once()
+    mock_qhbox_layout.return_value.setObjectName.assert_called_once_with("compoundHorizontalLayout")
+    assert mock_compound_data_type_class.context.main_vertical_layout.addLayout.call_count == (
+      1 if expected_widget_count > 0 else 0)
+    if expected_widget_count > 0:
+      mock_qhbox_layout.return_value.addWidget.call_count == expected_widget_count
+      mock_add_clear_button.assert_called_once_with(mock_compound_data_type_class.context.parent_frame,
+                                                    mock_qhbox_layout.return_value)
+      mock_add_delete_button.assert_called_once_with(mock_compound_data_type_class.context.parent_frame,
+                                                     mock_qhbox_layout.return_value, enable_delete_button)
+      mock_compound_data_type_class.context.main_vertical_layout.addLayout.assert_called_once_with(
+        mock_qhbox_layout.return_value)

--- a/tests/unit_tests/test_dataverse_controlled_vocab_frame.py
+++ b/tests/unit_tests/test_dataverse_controlled_vocab_frame.py
@@ -118,7 +118,7 @@ class TestControlledVocabFrame:
     controlled_vocab_frame.add_new_vocab_entry = mocker.MagicMock()
 
     # Act
-    controlled_vocab_frame.add_button_callback()
+    controlled_vocab_frame.add_button_click_handler()
 
     # Assert
     controlled_vocab_frame.logger.info.assert_called_once_with("Adding new vocabulary entry, value: %s",

--- a/tests/unit_tests/test_dataverse_controlled_vocabulary_data_type_class.py
+++ b/tests/unit_tests/test_dataverse_controlled_vocabulary_data_type_class.py
@@ -1,0 +1,340 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_controlled_vocabulary_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QComboBox, QFrame, QHBoxLayout, QPushButton, QVBoxLayout
+from _pytest.mark import param
+
+from pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class import ControlledVocabularyDataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+
+
+@pytest.fixture
+def mock_controlled_vocabulary_data_type_class(mocker):
+  context = mocker.MagicMock(spec=DataTypeClassContext)
+  context.main_vertical_layout = mocker.MagicMock(spec=QVBoxLayout)
+  context.add_push_button = mocker.MagicMock(spec=QPushButton)
+  context.parent_frame = mocker.MagicMock(spec=QFrame)
+  context.meta_field = {}
+  mocker.patch("pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.logging.getLogger")
+  return ControlledVocabularyDataTypeClass(context)
+
+
+class TestControlledVocabularyDataTypeClass:
+
+  @pytest.mark.parametrize(
+    "context, expected_logger_name",
+    [
+      (DataTypeClassContext(MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), MagicMock(spec=QFrame), {}),
+       "pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.ControlledVocabularyDataTypeClass"),
+      (DataTypeClassContext(MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), MagicMock(spec=QFrame), {}),
+       "pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.ControlledVocabularyDataTypeClass"),
+    ],
+    ids=["default_context", "another_default_context"]
+  )
+  def test_init_success_path(self, context, expected_logger_name):
+    # Act
+    instance = ControlledVocabularyDataTypeClass(context)
+
+    # Assert
+    assert instance.logger.name == expected_logger_name
+
+  @pytest.mark.parametrize(
+    "context, expected_exception",
+    [
+      (None, TypeError),
+    ],
+    ids=["context_is_none"]
+  )
+  def test_init_edge_cases(self, context, expected_exception):
+    # Act and Assert
+    with pytest.raises(expected_exception):
+      ControlledVocabularyDataTypeClass(context)
+
+  @pytest.mark.parametrize(
+    "context, expected_exception",
+    [
+      ("invalid_context", TypeError),
+    ],
+    ids=["context_is_invalid_type"]
+  )
+  def test_init_error_cases(self, context, expected_exception):
+    # Act and Assert
+    with pytest.raises(expected_exception):
+      ControlledVocabularyDataTypeClass(context)
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_entry, expected_value",
+    [
+      pytest.param(
+        {'valueTemplate': ['template1'], 'multiple': True},
+        ['template1'], 'template1',
+        id="multiple_true_with_valueTemplate"
+      ),
+      pytest.param(
+        {'valueTemplate': [], 'multiple': True},
+        [], None,
+        id="multiple_true_empty_valueTemplate"
+      ),
+      pytest.param(
+        {'valueTemplate': 'template1', 'multiple': False},
+        ["No Value", 'template1'], 'template1',
+        id="multiple_false_with_valueTemplate"
+      ),
+      pytest.param(
+        {'valueTemplate': [], 'multiple': False},
+        ["No Value"], "No Value",
+        id="multiple_false_empty_valueTemplate"
+      ),
+      pytest.param(
+        {'valueTemplate': None, 'multiple': False},
+        ["No Value"], "No Value",
+        id="multiple_false_none_valueTemplate"
+      ),
+    ]
+  )
+  def test_add_new_entry(self, mock_controlled_vocabulary_data_type_class, meta_field, expected_entry, expected_value):
+    # Arrange
+    mock_controlled_vocabulary_data_type_class.context.meta_field = meta_field
+    mock_controlled_vocabulary_data_type_class.add_new_vocab_entry = MagicMock()
+    # Act
+    mock_controlled_vocabulary_data_type_class.add_new_entry()
+
+    # Assert
+    mock_controlled_vocabulary_data_type_class.add_new_vocab_entry.assert_called_once_with(expected_entry,
+                                                                                           expected_value)
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_entries",
+    [
+      # Success path tests
+      ({"value": ["val1", "val2"], "valueTemplate": "template", "multiple": True},
+       [("template", "val1"), ("template", "val2")]),
+      ({"value": None, "valueTemplate": "template", "multiple": True}, [("template", None)]),
+      ({"value": "single_value", "valueTemplate": "template", "multiple": False},
+       [(["No Value", "template"], "single_value")]),
+      ({"value": None, "valueTemplate": "template", "multiple": False}, [(["No Value", "template"], "No Value")]),
+      ({"value": None, "valueTemplate": None, "multiple": False}, [(["No Value"], "No Value")]),
+
+      # Edge cases
+      ({"value": [], "valueTemplate": "template", "multiple": True}, [("template", None)]),
+      ({"value": [], "valueTemplate": "", "multiple": False}, [(["No Value"], "No Value")]),
+      ({"value": ["val1"], "valueTemplate": "", "multiple": True}, [("", "val1")]),
+      ({"value": ["val1"], "valueTemplate": None, "multiple": True}, [(None, "val1")])
+    ],
+    ids=[
+      "multiple_values_with_template",
+      "no_value_with_template_multiple",
+      "single_value_with_template",
+      "no_value_with_template_single",
+      "no_value_no_template_single",
+      "empty_value_list_with_template_multiple",
+      "empty_value_list_with_empty_template_single",
+      "single_value_with_empty_template_multiple",
+      "single_value_with_none_template_multiple"
+    ]
+  )
+  def test_populate_entry(self, mocker, mock_controlled_vocabulary_data_type_class, meta_field, expected_entries):
+    # Arrange
+    mock_controlled_vocabulary_data_type_class.context.meta_field = meta_field
+    mock_controlled_vocabulary_data_type_class.add_new_vocab_entry = MagicMock()
+    # Act
+    mock_controlled_vocabulary_data_type_class.populate_entry()
+
+    # Assert
+    mock_controlled_vocabulary_data_type_class.add_new_vocab_entry.assert_has_calls(
+      [mocker.call(e[0], e[1]) for e in expected_entries], any_order=True)
+
+  @pytest.mark.parametrize(
+    "meta_field, layout_exists, layout, expected_log, expected_warning, expected_error",
+    [
+      # Happy path: multiple entries
+      ({"multiple": True}, False, None,
+       ("Saved multiple entry modifications successfully, value: %s", {'multiple': True}), False, False),
+
+      # Happy path: single entry with correct layout
+      ({"multiple": False}, True, MagicMock(spec=QHBoxLayout),
+       ("Saved single entry modification successfully, value: %s", {'multiple': False}), False,
+       False),
+
+      # Edge case: single entry with incorrect layout type
+      ({"multiple": False}, True, MagicMock(spec=QVBoxLayout), None, False, True),
+
+      # Error case: no layout found
+      ({"multiple": False}, False, None, None, "Failed to save modifications, no layout found.", False),
+    ],
+    ids=[
+      "multiple_entries",
+      "single_entry_correct_layout",
+      "single_entry_incorrect_layout",
+      "no_layout_found",
+    ]
+  )
+  def test_save_modifications(self, mocker, mock_controlled_vocabulary_data_type_class, meta_field, layout_exists,
+                              layout, expected_log, expected_warning, expected_error):
+
+    # Arrange
+    mock_controlled_vocabulary_data_type_class.save_multiple_entries = mocker.MagicMock()
+    mock_controlled_vocabulary_data_type_class.save_single_entry = mocker.MagicMock()
+    mock_controlled_vocabulary_data_type_class.context.meta_field = meta_field
+    mock_controlled_vocabulary_data_type_class.context.main_vertical_layout.findChild.return_value = layout if layout_exists else None
+
+    # Act
+    mock_controlled_vocabulary_data_type_class.save_modifications()
+
+    # Assert
+    if expected_log:
+      mock_controlled_vocabulary_data_type_class.logger.info.assert_called_once_with(*expected_log)
+      if meta_field.get('multiple'):
+        mock_controlled_vocabulary_data_type_class.save_multiple_entries.assert_called_once_with()
+      else:
+        mock_controlled_vocabulary_data_type_class.save_single_entry.assert_called_once_with(layout)
+    else:
+      mock_controlled_vocabulary_data_type_class.logger.info.assert_not_called()
+
+    if expected_warning:
+      mock_controlled_vocabulary_data_type_class.logger.warning.assert_called_once_with(expected_warning)
+    else:
+      mock_controlled_vocabulary_data_type_class.logger.warning.assert_not_called()
+
+    if expected_error:
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_called_once_with(
+        "vocabHorizontalLayout not found!")
+    else:
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_not_called()
+
+  @pytest.mark.parametrize(
+    "combo_text, expected_value, log_error_called",
+    [
+      ("Valid Value", "Valid Value", False),  # success path
+      ("No Value", None, False),  # edge case: 'No Value'
+      ("", None, False),  # edge case: empty string
+      (None, None, True),  # error case: combo box not found
+      (None, None, True),  # error case: combo box not found
+      ("Another Value", "Another Value", False),  # success path with another value
+    ],
+    ids=[
+      "valid_value",
+      "no_value",
+      "empty_string",
+      "combo_box_not_found1",
+      "combo_box_not_found2",
+      "another_valid_value",
+    ]
+  )
+  def test_save_single_entry(self, mocker, mock_controlled_vocabulary_data_type_class, combo_text, expected_value,
+                             log_error_called, request):
+    # Arrange
+    layout = mocker.MagicMock(spec=QHBoxLayout)
+    combo_box = mocker.MagicMock(spec=QComboBox)
+    combo_box.currentText.return_value = combo_text
+    layout.itemAt.return_value.widget.return_value = combo_box if combo_text is not None else (
+      MagicMock() if request.node.callspec.id == "combo_box_not_found2" else None)
+
+    # Act
+    mock_controlled_vocabulary_data_type_class.save_single_entry(layout)
+
+    # Assert
+    if expected_value:
+      assert mock_controlled_vocabulary_data_type_class.context.meta_field['value'] == expected_value
+    else:
+      assert mock_controlled_vocabulary_data_type_class.logger.error.called == log_error_called
+
+    if log_error_called:
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_called_once_with("Combo box not found!")
+    else:
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_not_called()
+
+    if combo_text is not None:
+      combo_box.currentText.assert_called_once_with()
+    else:
+      combo_box.currentText.assert_not_called()
+
+  @pytest.mark.parametrize(
+    "initial_value, combo_texts, expected_value",
+    [
+      param([], ['Value1', 'Value2'], ['Value1', 'Value2'], id="success_path_with_two_values"),
+      param([], ['No Value', 'No Value', 'Value1'], ['Value1'], id="success_path_with_no_value"),
+      param([], ['Value1', 'Value1'], ['Value1'], id="success_path_with_duplicate_values"),
+      param([], [], [], id="success_path_with_no_comboboxes"),
+      param([], ['No Value', 'No Value'], [], id="success_path_with_only_no_value"),
+      param([], ['Value1', 'Value2', 'Value3'], ['Value1', 'Value2', 'Value3'], id="success_path_with_three_values"),
+      param([], ['Value1', 'Value2', 'Value1', None], ['Value1', 'Value2'],
+            id="success_path_with_duplicate_and_unique_values"),
+      param(None, ['Value1'], [], id="error_case_value_not_list"),
+    ],
+    ids=lambda val: val[-1]
+  )
+  def test_save_multiple_entries(self, mocker, mock_controlled_vocabulary_data_type_class, initial_value, combo_texts,
+                                 expected_value):
+    # Arrange
+    mock_controlled_vocabulary_data_type_class.context.meta_field['value'] = initial_value
+    mock_controlled_vocabulary_data_type_class.context.main_vertical_layout.count.return_value = len(combo_texts)
+
+    layouts = []
+    for text in combo_texts:
+      vocab_horizontal_layout = mocker.MagicMock(spec=QHBoxLayout)
+      combo_box = MagicMock(spec=QComboBox)
+      combo_box.currentText.return_value = text
+      vocab_horizontal_layout.addWidget(combo_box)
+      vocab_horizontal_layout.itemAt.return_value.widget.return_value = combo_box
+      vocab_horizontal_layout.layout.return_value = vocab_horizontal_layout
+      layouts.append(vocab_horizontal_layout)
+    mock_controlled_vocabulary_data_type_class.context.main_vertical_layout.itemAt.side_effect = layouts
+
+    # Act
+    mock_controlled_vocabulary_data_type_class.save_multiple_entries()
+
+    # Assert
+    if initial_value is None:
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_called_once_with("Value is not a list")
+    else:
+      assert set(mock_controlled_vocabulary_data_type_class.context.meta_field['value']) == set(expected_value)
+      mock_controlled_vocabulary_data_type_class.logger.error.assert_not_called()
+
+  @pytest.mark.parametrize(
+    "controlled_vocabulary, value, expected_items, expected_text",
+    [
+      param(["option1", "option2"], "option1", ["option1", "option2"], "option1", id="success_path_with_value"),
+      param(["option1", "option2"], None, ["option1", "option2"], "", id="success_path_without_value"),
+      param([], "option1", [], "option1", id="empty_vocabulary_with_value"),
+      param(None, None, [], "", id="empty_vocabulary_without_value"),
+    ],
+    ids=["success_path_with_value", "success_path_without_value", "empty_vocabulary_with_value",
+         "empty_vocabulary_without_value"]
+  )
+  def test_add_new_vocab_entry(self, mocker, mock_controlled_vocabulary_data_type_class, controlled_vocabulary, value,
+                               expected_items, expected_text):
+    # Arrange
+    mock_qh_box_layout = mocker.patch('pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.QHBoxLayout')
+    mock_qc_box = mocker.patch('pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.QComboBox')
+    mock_add_clear_button = mocker.patch(
+      'pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.add_clear_button')
+    mock_add_delete_button = mocker.patch(
+      'pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class.add_delete_button')
+
+    # Act
+    mock_controlled_vocabulary_data_type_class.add_new_vocab_entry(controlled_vocabulary, value)
+
+    # Assert
+    mock_qh_box_layout.assert_called_once()
+    mock_qh_box_layout.return_value.setObjectName.assert_called_once_with("vocabHorizontalLayout")
+    mock_qc_box.assert_called_once_with(parent=mock_controlled_vocabulary_data_type_class.context.parent_frame)
+    mock_qc_box.return_value.setObjectName.assert_called_once_with("vocabComboBox")
+    mock_qc_box.return_value.setToolTip.assert_called_once_with("Select the controlled vocabulary.")
+    mock_qc_box.return_value.addItems.assert_called_once_with(controlled_vocabulary or [])
+    mock_qc_box.return_value.setCurrentText.assert_called_once_with(value or "")
+    mock_qh_box_layout.return_value.addWidget.assert_called_once_with(mock_qc_box.return_value)
+    mock_add_clear_button(mock_controlled_vocabulary_data_type_class.context.parent_frame,
+                          mock_qh_box_layout.return_value)
+    mock_add_delete_button(mock_controlled_vocabulary_data_type_class.context.parent_frame,
+                           mock_qh_box_layout.return_value)
+    mock_controlled_vocabulary_data_type_class.context.main_vertical_layout.addLayout.assert_called_once_with(
+      mock_qh_box_layout.return_value)

--- a/tests/unit_tests/test_dataverse_data_type_class_base.py
+++ b/tests/unit_tests/test_dataverse_data_type_class_base.py
@@ -1,0 +1,84 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_data_type_class_base.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import pytest
+from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
+
+from pasta_eln.GUI.dataverse.data_type_class_base import DataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+
+
+class ConcreteDataTypeClass(DataTypeClass):
+  def add_new_entry(self) -> None:
+    raise NotImplementedError
+
+  def populate_entry(self) -> None:
+    raise NotImplementedError
+
+  def save_modifications(self) -> None:
+    raise NotImplementedError
+
+
+@pytest.fixture
+def valid_context(mocker):
+  return DataTypeClassContext(
+    mocker.MagicMock(spec=QVBoxLayout),
+    mocker.MagicMock(spec=QPushButton),
+    mocker.MagicMock(spec=QFrame),
+    {})
+
+
+class TestConcreteDataTypeClass:
+
+  @pytest.mark.parametrize(
+    "context, expected_exception",
+    [
+      ('valid_context', None),
+      (None, TypeError),
+      ("invalid_context", TypeError),
+    ],
+    ids=["valid_context", "none_context", "string_context"]
+  )
+  def test_init(self, context, expected_exception, request):
+    # Act and Assert
+    if expected_exception:
+      with pytest.raises(expected_exception):
+        ConcreteDataTypeClass(context)
+    else:
+      instance = ConcreteDataTypeClass(request.getfixturevalue(context))
+      assert instance.context == request.getfixturevalue(context)
+
+  @pytest.mark.parametrize(
+    "args, kwargs, expected_type",
+    [
+      ((), {}, ConcreteDataTypeClass),
+      ((1, 2, 3), {}, ConcreteDataTypeClass),
+      ((), {"key": "value"}, ConcreteDataTypeClass),
+    ],
+    ids=["no_args", "positional_args", "keyword_args"]
+  )
+  def test_new(self, args, kwargs, expected_type):
+    # Act
+    instance = ConcreteDataTypeClass.__new__(ConcreteDataTypeClass, *args, **kwargs)
+
+    # Assert
+    assert isinstance(instance, expected_type)
+
+  def test_abstract_methods(self, valid_context):
+    # Arrange
+    instance = ConcreteDataTypeClass(valid_context)
+
+    # Act and Assert
+    with pytest.raises(NotImplementedError):
+      instance.add_new_entry()
+
+    with pytest.raises(NotImplementedError):
+      instance.populate_entry()
+
+    with pytest.raises(NotImplementedError):
+      instance.save_modifications()

--- a/tests/unit_tests/test_dataverse_data_type_class_context.py
+++ b/tests/unit_tests/test_dataverse_data_type_class_context.py
@@ -1,0 +1,56 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_data_type_class_context.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
+
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+
+
+class TestDataTypeClassContext:
+  @pytest.mark.parametrize(
+    "main_vertical_layout, add_push_button, parent_frame, meta_field",
+    [
+      (MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), MagicMock(spec=QFrame), {"key": "value"}),
+      (MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), MagicMock(spec=QFrame), {"another_key": 123}),
+    ],
+    ids=["valid_case_1", "valid_case_2"]
+  )
+  def test_data_type_class_context_success_path(self, main_vertical_layout, add_push_button, parent_frame, meta_field):
+    # Act
+    context = DataTypeClassContext(main_vertical_layout, add_push_button, parent_frame, meta_field)
+
+    # Assert
+    assert context.main_vertical_layout == main_vertical_layout
+    assert context.add_push_button == add_push_button
+    assert context.parent_frame == parent_frame
+    assert context.meta_field == meta_field
+
+  @pytest.mark.parametrize(
+    "main_vertical_layout, add_push_button, parent_frame, meta_field, expected_exception, expected_message",
+    [
+      (None, MagicMock(spec=QPushButton), MagicMock(spec=QFrame), {"key": "value"}, ValueError,
+       "main_vertical_layout must be a QVBoxLayout!"),
+      (MagicMock(spec=QVBoxLayout), None, MagicMock(spec=QFrame), {"key": "value"}, ValueError,
+       "add_push_button must be a QPushButton!"),
+      (MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), None, {"key": "value"}, ValueError,
+       "parent_frame must be a QFrame!"),
+      (MagicMock(spec=QVBoxLayout), MagicMock(spec=QPushButton), MagicMock(spec=QFrame), None, ValueError,
+       "meta_field must be a dict!"),
+    ],
+    ids=["invalid_main_vertical_layout", "invalid_add_push_button", "invalid_parent_frame", "invalid_meta_field"]
+  )
+  def test_data_type_class_context_error_cases(self, main_vertical_layout, add_push_button, parent_frame, meta_field,
+                                               expected_exception, expected_message):
+    # Act and Assert
+    with pytest.raises(expected_exception) as exc_info:
+      DataTypeClassContext(main_vertical_layout, add_push_button, parent_frame, meta_field)
+
+    assert str(exc_info.value) == expected_message

--- a/tests/unit_tests/test_dataverse_data_type_class_factory.py
+++ b/tests/unit_tests/test_dataverse_data_type_class_factory.py
@@ -1,0 +1,96 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_data_type_class_factory.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import pytest
+from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
+
+from pasta_eln.GUI.dataverse.compound_data_type_class import CompoundDataTypeClass
+from pasta_eln.GUI.dataverse.controlled_vocabulary_data_type_class import ControlledVocabularyDataTypeClass
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.data_type_class_factory import DataTypeClassFactory
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.primitive_data_type_class import PrimitiveDataTypeClass
+
+
+@pytest.fixture
+def context(mocker):
+  return DataTypeClassContext(
+    mocker.MagicMock(spec=QVBoxLayout),
+    mocker.MagicMock(spec=QPushButton),
+    mocker.MagicMock(spec=QFrame),
+    {})
+
+
+@pytest.fixture
+def factory(context):
+  return DataTypeClassFactory(context)
+
+
+class TestDataTypeClassFactory:
+
+  @pytest.mark.parametrize("class_name, expected_type", [
+    (DataTypeClassName.PRIMITIVE, PrimitiveDataTypeClass),
+    (DataTypeClassName.COMPOUND, CompoundDataTypeClass),
+    (DataTypeClassName.CONTROLLED_VOCAB, ControlledVocabularyDataTypeClass)
+  ], ids=["primitive", "compound", "controlled_vocab"])
+  def test_make_data_type_class(self, factory, class_name, expected_type):
+    # Act
+    result = factory.make_data_type_class(class_name)
+
+    # Assert
+    assert isinstance(result, expected_type)
+
+  @pytest.mark.parametrize("class_name", [
+    "INVALID_CLASS_NAME",
+    None,
+    123
+  ], ids=["invalid_string", "none", "integer"])
+  def test_make_data_type_class_invalid(self, factory, class_name):
+    # Act & Assert
+    with pytest.raises(ValueError) as exc_info:
+      factory.make_data_type_class(class_name)
+
+    assert str(exc_info.value) == f"Invalid data type class name: {class_name}"
+
+  def test_new_instance(self, context):
+    # Act
+    instance = DataTypeClassFactory(context)
+
+    # Assert
+    assert isinstance(instance, DataTypeClassFactory)
+
+  def test_init(self, factory, context):
+    # Assert
+    assert factory.context == context
+    assert DataTypeClassName.PRIMITIVE in factory.factory_map
+    assert DataTypeClassName.COMPOUND in factory.factory_map
+    assert DataTypeClassName.CONTROLLED_VOCAB in factory.factory_map
+
+  def test_make_primitive_data_type_class(self, factory, context):
+    # Act
+    result = factory.make_primitive_data_type_class()
+
+    # Assert
+    assert isinstance(result, PrimitiveDataTypeClass)
+    assert result.context == context
+
+  def test_make_compound_data_type_class(self, factory, context):
+    # Act
+    result = factory.make_compound_data_type_class()
+
+    # Assert
+    assert isinstance(result, CompoundDataTypeClass)
+    assert result.context == context
+
+  def test_make_controlled_vocab_data_type_class(self, factory, context):
+    # Act
+    result = factory.make_controlled_vocab_data_type_class()
+
+    # Assert
+    assert isinstance(result, ControlledVocabularyDataTypeClass)
+    assert result.context == context

--- a/tests/unit_tests/test_dataverse_data_type_class_names.py
+++ b/tests/unit_tests/test_dataverse_data_type_class_names.py
@@ -1,0 +1,71 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_data_type_class_names.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import pytest
+
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+
+
+class TestDataTypeClassName:
+  @pytest.mark.parametrize(
+    "data_type, expected_str",
+    [
+      (DataTypeClassName.PRIMITIVE, "primitive"),
+      (DataTypeClassName.COMPOUND, "compound"),
+      (DataTypeClassName.CONTROLLED_VOCAB, "controlledVocabulary"),
+    ],
+    ids=[
+      "primitive_str",
+      "compound_str",
+      "controlled_vocab_str"
+    ]
+  )
+  def test_data_type_class_name_str(self, data_type, expected_str):
+    # Act
+    result = str(data_type)
+
+    # Assert
+    assert result == expected_str
+
+  @pytest.mark.parametrize(
+    "data_type, expected_value",
+    [
+      (DataTypeClassName.PRIMITIVE, "primitive"),
+      (DataTypeClassName.COMPOUND, "compound"),
+      (DataTypeClassName.CONTROLLED_VOCAB, "controlledVocabulary"),
+    ],
+    ids=[
+      "primitive_value",
+      "compound_value",
+      "controlled_vocab_value"
+    ]
+  )
+  def test_data_type_class_name_value(self, data_type, expected_value):
+    # Act
+    result = data_type.value
+
+    # Assert
+    assert result == expected_value
+
+  @pytest.mark.parametrize(
+    "invalid_value",
+    [
+      "simple",
+      "complex",
+      "vocabulary",
+    ],
+    ids=[
+      "invalid_simple",
+      "invalid_complex",
+      "invalid_vocabulary"
+    ]
+  )
+  def test_data_type_class_name_invalid(self, invalid_value):
+    # Act and Assert
+    with pytest.raises(ValueError):
+      DataTypeClassName(invalid_value)

--- a/tests/unit_tests/test_dataverse_edit_metadata_dialog.py
+++ b/tests/unit_tests/test_dataverse_edit_metadata_dialog.py
@@ -183,7 +183,7 @@ class TestDataverseEditMetadataDialog:
     mock_edit_metadata_dialog.metadata_summary_dialog.summaryTextEdit = mocker.MagicMock()
     mock_edit_metadata_dialog.metadata_summary_dialog.summaryTextEdit.setText = mocker.MagicMock()
     mock_edit_metadata_dialog.controlled_vocab_frame = mocker.MagicMock() if has_vocab_frame else None
-    mock_edit_metadata_dialog.primitive_compound_frame = mocker.MagicMock() if has_primitive_frame else None
+    mock_edit_metadata_dialog.metadata_frame = mocker.MagicMock() if has_primitive_frame else None
     mock_get_formatted = mocker.patch("pasta_eln.GUI.dataverse.edit_metadata_dialog.get_formatted_metadata_message",
                                       return_value=expected_message)
 
@@ -197,7 +197,7 @@ class TestDataverseEditMetadataDialog:
     if has_vocab_frame:
       mock_edit_metadata_dialog.controlled_vocab_frame.save_modifications.assert_called_once()
     if has_primitive_frame:
-      mock_edit_metadata_dialog.primitive_compound_frame.save_modifications.assert_called_once()
+      mock_edit_metadata_dialog.metadata_frame.save_modifications.assert_called_once()
     mock_edit_metadata_dialog.logger.info.assert_called_with("Saving Config Model...")
 
   # Success path tests with various realistic test values
@@ -226,7 +226,7 @@ class TestDataverseEditMetadataDialog:
     mock_edit_metadata_dialog.typesComboBox.currentData.return_value = new_metadata_type
     mock_edit_metadata_dialog.metadataScrollVerticalLayout.count.return_value = 2
     if test_id == 'success_primitive_pre_exists':
-      mock_edit_metadata_dialog.primitive_compound_frame = mock_dependencies['primitive_compound_frame'].return_value
+      mock_edit_metadata_dialog.metadata_frame = mock_dependencies['primitive_compound_frame'].return_value
       mock_edit_metadata_dialog.controlled_vocab_frame = mock_dependencies['controlled_vocab_frame'].return_value
 
     # Act
@@ -249,8 +249,8 @@ class TestDataverseEditMetadataDialog:
       mock_edit_metadata_dialog.metadataScrollVerticalLayout.addWidget.assert_called_once_with(
         controlled_vocab_frame.return_value.instance)
     if test_id == 'success_primitive_pre_exists':
-      mock_edit_metadata_dialog.primitive_compound_frame.save_modifications.assert_called_once()
-      mock_edit_metadata_dialog.primitive_compound_frame.instance.close.assert_called_once()
+      mock_edit_metadata_dialog.metadata_frame.save_modifications.assert_called_once()
+      mock_edit_metadata_dialog.metadata_frame.instance.close.assert_called_once()
       mock_edit_metadata_dialog.controlled_vocab_frame.save_modifications.assert_called_once()
       mock_edit_metadata_dialog.controlled_vocab_frame.instance.close.assert_called_once()
 

--- a/tests/unit_tests/test_dataverse_metadata_frame_base.py
+++ b/tests/unit_tests/test_dataverse_metadata_frame_base.py
@@ -1,0 +1,75 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_metadata_frame_base.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+import pytest
+from PySide6.QtWidgets import QFrame
+
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
+
+
+class ConcreteMetadataFrame(MetadataFrame):
+  def load_ui(self) -> None:
+    pass
+
+  def save_modifications(self) -> None:
+    pass
+
+
+@pytest.fixture
+def qframe_instance(mocker):
+  return mocker.MagicMock(spec=QFrame)
+
+
+class TestDataverseMetadataFrame:
+  @pytest.mark.parametrize(
+    "args, kwargs, expected_type",
+    [
+      ((), {}, ConcreteMetadataFrame),
+      ((1, 2, 3), {}, ConcreteMetadataFrame),
+      ((), {"key": "value"}, ConcreteMetadataFrame),
+    ],
+    ids=[
+      "no_args_no_kwargs",
+      "with_args_no_kwargs",
+      "no_args_with_kwargs",
+    ]
+  )
+  def test_metadata_frame_new(self, args, kwargs, expected_type):
+    # Act
+    instance = MetadataFrame.__new__(ConcreteMetadataFrame, *args, **kwargs)
+
+    # Assert
+    assert isinstance(instance, expected_type)
+
+  def test_metadata_frame_init(self, qframe_instance):
+    # Act
+    instance = ConcreteMetadataFrame(qframe_instance)
+
+    # Assert
+    assert instance.instance == qframe_instance
+
+  @pytest.mark.parametrize(
+    "method_name",
+    [
+      "load_ui",
+      "save_modifications",
+    ],
+    ids=[
+      "load_ui_method",
+      "save_modifications_method",
+    ]
+  )
+  def test_abstract_methods_implementation(self, qframe_instance, method_name):
+    # Arrange
+    instance = ConcreteMetadataFrame(qframe_instance)
+
+    # Act
+    method = getattr(instance, method_name)
+
+    # Assert
+    assert callable(method)

--- a/tests/unit_tests/test_dataverse_metadata_frame_factory.py
+++ b/tests/unit_tests/test_dataverse_metadata_frame_factory.py
@@ -1,0 +1,136 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_metadata_frame_factory.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QFrame
+from _pytest.mark import param
+
+from pasta_eln.GUI.dataverse.controlled_vocab_frame import ControlledVocabFrame
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
+from pasta_eln.GUI.dataverse.metadata_frame_base import MetadataFrame
+from pasta_eln.GUI.dataverse.metadata_frame_factory import MetadataFrameFactory, make_controlled_vocab_frame, \
+  make_primitive_compound_frame
+from pasta_eln.GUI.dataverse.primitive_compound_frame import PrimitiveCompoundFrame
+
+
+# Mock functions to simulate the behavior of the actual frame creation functions
+def mock_make_primitive_compound_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  return MetadataFrame(MagicMock(spec=QFrame))
+
+
+def mock_make_controlled_vocab_frame(metadata_field: dict[str, Any]) -> MetadataFrame:
+  return MetadataFrame(MagicMock(spec=QFrame))
+
+
+@pytest.fixture
+def metadata_frame_factory(mocker):
+  mocker.patch("pasta_eln.GUI.dataverse.metadata_frame_factory.make_primitive_compound_frame",
+               side_effect=mock_make_primitive_compound_frame)
+  mocker.patch("pasta_eln.GUI.dataverse.metadata_frame_factory.make_controlled_vocab_frame",
+               side_effect=mock_make_controlled_vocab_frame)
+  return MetadataFrameFactory()
+
+
+class TestMetadataFrameFactory:
+
+  @pytest.mark.parametrize(
+    "class_name, metadata_field, expected_type",
+    [
+      (DataTypeClassName.PRIMITIVE, {"field1": "value1"}, MetadataFrame),
+      (DataTypeClassName.COMPOUND, {"field2": "value2"}, MetadataFrame),
+      (DataTypeClassName.CONTROLLED_VOCAB, {"field3": "value3"}, MetadataFrame),
+    ],
+    ids=["primitive", "compound", "controlled_vocab"]
+  )
+  def test_make_metadata_frame_happy_path(self, metadata_frame_factory, class_name, metadata_field, expected_type):
+    # Act
+    result = metadata_frame_factory.make_metadata_frame(class_name, metadata_field)
+
+    # Assert
+    assert isinstance(result, expected_type)
+
+  @pytest.mark.parametrize(
+    "class_name, metadata_field",
+    [
+      (DataTypeClassName.PRIMITIVE, {}),
+      (DataTypeClassName.COMPOUND, {"field": None}),
+      (DataTypeClassName.CONTROLLED_VOCAB, {"field": ""}),
+    ],
+    ids=["primitive_empty", "compound_none", "controlled_vocab_empty"]
+  )
+  def test_make_metadata_frame_edge_cases(self, metadata_frame_factory, class_name, metadata_field):
+    # Act
+    result = metadata_frame_factory.make_metadata_frame(class_name, metadata_field)
+
+    # Assert
+    assert isinstance(result, MetadataFrame)
+
+  @pytest.mark.parametrize(
+    "class_name, metadata_field, expected_exception, expected_message",
+    [
+      ("INVALID_CLASS", {"field": "value"}, ValueError, "Invalid data type class name: INVALID_CLASS"),
+      (None, {"field": "value"}, ValueError, "Invalid data type class name: None"),
+    ],
+    ids=["invalid_class", "none_class"]
+  )
+  def test_make_metadata_frame_error_cases(self, metadata_frame_factory, class_name, metadata_field, expected_exception,
+                                           expected_message):
+    # Act and Assert
+    with pytest.raises(expected_exception) as exc_info:
+      metadata_frame_factory.make_metadata_frame(class_name, metadata_field)
+
+    assert str(exc_info.value) == expected_message
+
+  @pytest.mark.parametrize(
+    "metadata_field, expected_type",
+    [
+      param({"key1": "value1"}, PrimitiveCompoundFrame, id="simple_dict"),
+      param({"key2": 123, "key3": [1, 2, 3]}, PrimitiveCompoundFrame, id="complex_dict"),
+      param({}, PrimitiveCompoundFrame, id="empty_dict"),
+    ],
+    ids=["simple_dict", "complex_dict", "empty_dict"]
+  )
+  def test_make_primitive_compound_frame_happy_path(self, mocker, metadata_field, expected_type):
+    # Arrange
+    mocker.patch("pasta_eln.GUI.dataverse.metadata_frame_factory.PrimitiveCompoundFrame",
+                 return_value=MagicMock(spec=PrimitiveCompoundFrame, metadata_field=metadata_field))
+
+    # Act
+    result = make_primitive_compound_frame(metadata_field)
+
+    # Assert
+    assert isinstance(result, expected_type)
+    assert result.metadata_field == metadata_field
+
+  @pytest.mark.parametrize(
+    "metadata_field, expected_type",
+    [
+      # Happy path tests
+      param({"field1": "value1"}, ControlledVocabFrame, id="simple_dict"),
+      param({"field1": 123, "field2": [1, 2, 3]}, ControlledVocabFrame, id="complex_dict"),
+      param({"field1": None}, ControlledVocabFrame, id="none_value"),
+
+      # Edge cases
+      param({}, ControlledVocabFrame, id="empty_dict"),
+      param({"field1": ""}, ControlledVocabFrame, id="empty_string_value"),
+      param({"field1": " "}, ControlledVocabFrame, id="whitespace_string_value"),
+    ],
+    ids=lambda x: x[2]
+  )
+  def test_make_controlled_vocab_frame(self, mocker, metadata_field, expected_type):
+    # Arrange
+    mocker.patch("pasta_eln.GUI.dataverse.metadata_frame_factory.ControlledVocabFrame",
+                 return_value=MagicMock(spec=ControlledVocabFrame, metadata_field=metadata_field))
+    # Act
+    result = make_controlled_vocab_frame(metadata_field)
+
+    # Assert
+    assert isinstance(result, expected_type)

--- a/tests/unit_tests/test_dataverse_primitive_compound_frame.py
+++ b/tests/unit_tests/test_dataverse_primitive_compound_frame.py
@@ -6,635 +6,209 @@
 #  Filename: test_dataverse_primitive_compound_frame.py
 #
 #  You should have received a copy of the license with this file. Please refer the license file for more information.
-from unittest.mock import patch
+
+from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtCore import QDate
-from PySide6.QtWidgets import QBoxLayout
+from PySide6.QtWidgets import QFrame, QPushButton, QVBoxLayout
 
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.data_type_class_names import DataTypeClassName
 from pasta_eln.GUI.dataverse.primitive_compound_frame import PrimitiveCompoundFrame
 
 
-# Mock the Qt dependencies to avoid issues with the actual GUI components during testing
 @pytest.fixture
-def qtbot(mocker):
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QFrame')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QLineEdit')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QDateTimeEdit')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QVBoxLayout')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QHBoxLayout')
-  mocker.patch.object(PrimitiveCompoundFrame, 'addPushButton', create=True)
-  mocker.patch.object(PrimitiveCompoundFrame, 'mainVerticalLayout', create=True)
+def mock_data_type_class_factory():
+  with patch('pasta_eln.GUI.dataverse.primitive_compound_frame.DataTypeClassFactory') as mock_factory:
+    yield mock_factory
 
 
-# Fixture to create a PrimitiveCompoundFrame instance with a mocked parent
 @pytest.fixture
-def primitive_compound_frame(qtbot, mocker):
+def mock_data_type_class():
+  with patch('pasta_eln.GUI.dataverse.primitive_compound_frame.DataTypeClass') as mock_class:
+    yield mock_class
+
+
+@pytest.fixture
+def mock_qframe():
+  with patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QFrame') as mock_frame:
+    mock_frame.return_value = MagicMock(spec=QFrame)
+    yield mock_frame
+
+
+@pytest.fixture
+def mock_logger():
+  with patch('pasta_eln.GUI.dataverse.primitive_compound_frame.logging.getLogger') as mock_logger:
+    yield mock_logger
+
+
+@pytest.fixture
+def mock_primitive_compound_frame(mocker, mock_logger, mock_data_type_class_factory, mock_data_type_class, mock_qframe):
   mocker.patch(
-    'pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.logging.getLogger')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.add_clear_button')
-  mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.add_delete_button')
-  type_field = {
-    'typeClass': 'primitive',
-    'multiple': False,
-    'typeName': 'testType',
-    'value': 'testValue',
-    'valueTemplate': 'testTemplate'
-  }
-  return PrimitiveCompoundFrame(type_field)
-
-
-def create_mock_line_edit(mocker, name, text):
-  line_edit = mocker.MagicMock()
-  line_edit.objectName.return_value = f"{name}LineEdit"
-  line_edit.text.return_value = text
-  line_edit.widget.return_value = line_edit
-  return line_edit
+    "pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi")
+  mocker.patch.object(PrimitiveCompoundFrame, 'addPushButton', MagicMock(spec=QPushButton), create=True)
+  mocker.patch.object(PrimitiveCompoundFrame, 'mainVerticalLayout', MagicMock(spec=QVBoxLayout), create=True)
+  frame = PrimitiveCompoundFrame({"typeClass": "primitive", "multiple": False, "value": "test_value"})
+  mocker.resetall()
+  yield frame
 
 
 class TestDataversePrimitiveCompoundFrame:
-  # Parametrized test for __init__ method happy path
-  # Parametrized test for the happy path of PrimitiveCompoundFrame initialization
-  @pytest.mark.parametrize("type_field, expected_logger_name", [
-    # Test ID: #1
-    (
-        {'typeClass': 'primitive', 'multiple': True, 'typeName': 'testType', 'value': [],
-         'valueTemplate': ['testTemplate']},
-        "pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame"
-    ),
-    # Test ID: #2
-    (
-        {'typeClass': 'compound', 'multiple': False, 'typeName': 'testType', 'value': {},
-         'valueTemplate': {'testType': {'value': 'testValue'}}},
-        "pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame"
-    ),
-  ], ids=["happy-path-primitive-multiple", "happy-path-compound-single"])
-  def test_primitive_compound_frame_init(self, mocker, qtbot, type_field, expected_logger_name):
+
+  @pytest.mark.parametrize("meta_field, expected_type_class", [
+    ({"typeClass": "primitive"}, DataTypeClassName("primitive")),
+    ({"typeClass": "compound"}, DataTypeClassName("compound")),
+    ({"typeClass": "controlledVocabulary"}, DataTypeClassName("controlledVocabulary")),
+  ], ids=["type_class_primitive", "type_class_compound", "type_class_controlledVocabulary"])
+  def test_primitive_compound_frame_initialization(self, mocker, mock_logger, mock_data_type_class_factory,
+                                                   mock_data_type_class, mock_qframe, meta_field, expected_type_class):
     # Arrange
-    mock_load_ui = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.load_ui')
-    with patch(
-        'pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi') as mock_setup_ui:
-      # Act
-      frame = PrimitiveCompoundFrame(type_field)
-
-      # Assert
-      assert frame.logger.name == expected_logger_name
-      mock_setup_ui.assert_called_once()
-      mock_load_ui.assert_called_once()
-
-  @pytest.mark.parametrize("meta_field, expected_disabled, expected_calls, test_id", [
-    # Happy path tests
-    ({"typeClass": "primitive", "multiple": False}, True, "primitive_entry", "success_primitive_single"),
-    ({"typeClass": "primitive", "multiple": True}, False, "primitive_entry", "success_primitive_multiple"),
-    ({"typeClass": "compound", "multiple": True, "value": [], "valueTemplate": [{}]}, False, "compound_entry_empty",
-     "success_compound_multiple_empty"),
-    ({"typeClass": "compound", "multiple": True, "value": [{}], "valueTemplate": [{}]}, False, "compound_entry_filled",
-     "success_compound_multiple_filled"),
-    ({"typeClass": "compound", "multiple": False, "value": {}, "valueTemplate": {}}, True, "compound_entry_single",
-     "success_compound_single"),
-
-    # Edge cases
-    ({"typeClass": "compound", "multiple": False, "value": None, "valueTemplate": {}}, True, "compound_entry_none",
-     "edge_compound_none_value"),
-
-    # Error cases
-    ({"typeClass": "unknown"}, None, "error", "error_unknown_typeClass"),
-    ({"typeClass": "compound", "multiple": False, "value": None, "valueTemplate": None}, True, "compound_entry_single",
-     "error_compound_value_value_template_none"),
-    ({"typeClass": "compound", "multiple": False}, True, "compound_entry_single",
-     "error_compound_value_value_template_missing"),
-    ({}, False, "empty_meta_field",
-     "error_empty_meta_field"),
-  ])
-  def test_load_ui(self, mocker, primitive_compound_frame, meta_field, expected_disabled, expected_calls, test_id):
-    # Arrange
-    mocker.resetall()
-    primitive_compound_frame.meta_field = meta_field
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.populate_primitive_entry')
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.populate_compound_entry')
+    mock_setup_ui = mocker.patch(
+      "pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi")
+    mock_metadata_frame_init = mocker.patch(
+      "pasta_eln.GUI.dataverse.metadata_frame_base.MetadataFrame.__init__")
+    mock_data_type_class_context = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.DataTypeClassContext',
+                                                MagicMock(spec=DataTypeClassContext))
+    mocker.patch.object(PrimitiveCompoundFrame, 'addPushButton', MagicMock(spec=QPushButton), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'mainVerticalLayout', MagicMock(spec=QVBoxLayout), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'load_ui')
+    mock_logger.reset_mock()
 
     # Act
-    primitive_compound_frame.load_ui()
+    frame = PrimitiveCompoundFrame(meta_field)
 
     # Assert
-    primitive_compound_frame.logger.info.assert_called_with("Loading UI for %s", meta_field)
-    if expected_disabled is not None and expected_disabled:
-      primitive_compound_frame.addPushButton.setDisabled.assert_called_with(expected_disabled)
-    if "primitive_entry" in expected_calls:
-      primitive_compound_frame.populate_primitive_entry.assert_called
-    if "compound_entry_empty" in expected_calls:
-      primitive_compound_frame.populate_compound_entry.assert_called_with({}, {})
-    if "compound_entry_filled" in expected_calls:
-      primitive_compound_frame.populate_compound_entry.assert_called_with({}, {})
-    if "compound_entry_single" in expected_calls:
-      primitive_compound_frame.populate_compound_entry.assert_called_with(meta_field.get('value'),
-                                                                          meta_field.get('valueTemplate'), False)
-    if "error" in expected_calls:
-      primitive_compound_frame.logger.error.assert_called_with("Unknown typeClass: %s", 'unknown')
-
-  # Parametrized test for the add_new_entry method
-  @pytest.mark.parametrize("meta_field, expected_error_log", [
-    # Test ID: #3
-    (
-        {'typeClass': 'primitive', 'multiple': False, 'typeName': 'testType', 'value': 'testValue',
-         'valueTemplate': ['testTemplate']},
-        'Add operation not supported for non-multiple entries'
-    ),
-    # Test ID: #4
-    (
-        {'typeClass': 'unknown', 'multiple': True, 'typeName': 'testType', 'value': [],
-         'valueTemplate': ['testTemplate']},
-        ('Unknown type class: %s', 'unknown')
-    ),
-  ], ids=["error-primitive-multiple-false", "error-unknown-typeclass"])
-  def test_add_new_entry_errors(self, mocker, primitive_compound_frame, meta_field, expected_error_log):
-    # Arrange
-    primitive_compound_frame.meta_field = meta_field
-    primitive_compound_frame.logger.error = mocker.MagicMock()
-
-    # Act
-    primitive_compound_frame.add_button_click_handler()
-    # Assert
-    if isinstance(expected_error_log, str):
-      primitive_compound_frame.logger.error.assert_called_with(expected_error_log)
-    else:
-      primitive_compound_frame.logger.error.assert_called_with(*expected_error_log)
-
-  # Parametrized test case for the add_delete_button method
-
-  @pytest.mark.parametrize(
-    "parent_layout, expected_exception",
-    [
-      (None, AttributeError),  # error case: parent is None
-    ],
-    ids=["parent_none"]
-  )
-  def test_add_delete_button_with_invalid_parent(self, primitive_compound_frame, qtbot, mocker, parent_layout,
-                                                 expected_exception):
-    # Arrange
-    mock_self = mocker.MagicMock()
-    mock_self.instance = mocker.MagicMock()
-
-    # Act / Assert
-    with pytest.raises(expected_exception):
-      primitive_compound_frame.add_delete_button(parent_layout)
-
-  @pytest.mark.parametrize(
-    "test_id, type_name, type_value, template_value, expected_placeholder, expected_tooltip, expected_object_name", [
-      (
-          "happy-1", "Name", "John Doe", "John Smith", "Enter the Name here.",
-          "Enter the Name value here. e.g. John Smith",
-          "NameLineEdit"),
-      ("happy-2", "Date", "", "2023-01-01", "Enter the Date here.", "Enter the Date value here. e.g. 2023-01-01",
-       "DateLineEdit"),
-      ("happy-3", "Number", "42", "100", "Enter the Number here.", "Enter the Number value here. e.g. 100",
-       "NumberLineEdit"),
-    ])
-  def test_create_line_edit_happy_path(self, mocker, primitive_compound_frame, test_id, type_name, type_value,
-                                       template_value, expected_placeholder,
-                                       expected_tooltip, expected_object_name):
-    # Arrange
-    mocker.resetall()
-    adjust_type_name = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.adjust_type_name',
-                                    return_value=type_name)
-
-    # Act
-    line_edit = primitive_compound_frame.create_line_edit(type_name=type_name, type_value=type_value,
-                                                          template_value=template_value)
-
-    # Assert
-    adjust_type_name.assert_called_once_with(type_name)
-    line_edit.setPlaceholderText.assert_called_once_with(expected_placeholder)
-    line_edit.setToolTip.assert_called_once_with(expected_tooltip)
-    line_edit.setObjectName.assert_called_once_with(expected_object_name)
-    line_edit.setText.assert_called_once_with(type_value)
-    line_edit.setClearButtonEnabled.assert_called_once_with(True)
-
-  # Parametrized test for edge cases
-  @pytest.mark.parametrize("test_id, type_name, type_value, template_value", [
-    ("edge-1", "", "", None),  # Empty type_name and type_value
-    ("edge-2", "LongTypeName" * 10, "Value", "Template"),  # Very long type_name
-    ("edge-3", "Name", "John Doe" * 10, "John Smith"),  # Very long type_value
-  ])
-  def test_create_line_edit_edge_cases(self, mocker, test_id, primitive_compound_frame, type_name, type_value,
-                                       template_value):
-    # Arrange
-    mocker.resetall()
-
-    # Act
-    line_edit = primitive_compound_frame.create_line_edit(type_name=type_name, type_value=type_value,
-                                                          template_value=template_value)
-
-    # Assert
-    assert line_edit is not None
-    line_edit.setObjectName.assert_called_once_with(f"{type_name}LineEdit")
-
-  # Parametrized test cases for create_date_time_widget
-  @pytest.mark.parametrize(
-    "type_name, type_value, template_value, expected_date, expected_tooltip, expected_object_name",
-    [
-      # Success path tests
-      ("birthdate", "1990-01-01", "2000-01-01", QDate(1990, 1, 1),
-       "Enter the birthdate value here. e.g. 2000-01-01, Minimum possible date is 0100-01-02", "birthdateDateTimeEdit"),
-      ("eventdate", "2023-10-10", "2023-01-01", QDate(2023, 10, 10),
-       "Enter the eventdate value here. e.g. 2023-01-01, Minimum possible date is 0100-01-02", "eventdateDateTimeEdit"),
-
-      # Edge cases
-      ("startdate", "0100-01-02", None, QDate(100, 1, 2),
-       "Enter the startdate value here. e.g. None, Minimum possible date is 0100-01-02", "startdateDateTimeEdit"),
-      ("enddate", "No Value", "2022-12-31", QDate(1, 1, 1),
-       "Enter the enddate value here. e.g. 2022-12-31, Minimum possible date is 0100-01-02", "enddateDateTimeEdit"),
-
-      # Error cases
-      ("invaliddate", "invalid", None, QDate(1, 1, 1),
-       "Enter the invaliddate value here. e.g. None, Minimum possible date is 0100-01-02", "invaliddateDateTimeEdit"),
-    ],
-    ids=[
-      "success_path_birthdate",
-      "success_path_eventdate",
-      "edge_case_startdate",
-      "edge_case_enddate",
-      "error_case_invaliddate",
-    ]
-  )
-  def test_create_date_time_widget(self, mocker, primitive_compound_frame, type_name, type_value, template_value,
-                                   expected_date, expected_tooltip,
-                                   expected_object_name):
-    # Arrange
-    mock_qdate_time_edit = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QDateTimeEdit')
-    adjust_type_name = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.adjust_type_name',
-                                    return_value=type_name)
-
-    # Act
-    date_time_widget = primitive_compound_frame.create_date_time_widget(type_name, type_value, template_value)
-
-    # Assert
-    mock_qdate_time_edit.assert_called_once_with(parent=primitive_compound_frame.instance)
-    assert date_time_widget == mock_qdate_time_edit.return_value
-    date_time_widget.setSpecialValueText.assert_called_once_with("No Value")
-    date_time_widget.setMinimumDate.assert_called_once_with(QDate.fromString("0100-01-01", 'yyyy-MM-dd'))
-    adjust_type_name.assert_called_once_with(type_name)
-    date_time_widget.setToolTip.assert_called_once_with(
-      f"Enter the {type_name} value here. e.g. {template_value}, Minimum possible date is 0100-01-02")
-    date_time_widget.setObjectName.assert_called_once_with(f"{type_name}DateTimeEdit")
-    date_time_widget.setDate.assert_called_once_with(QDate.fromString(type_value, 'yyyy-MM-dd')
-                                                     if type_value and type_value != 'No Value'
-                                                     else QDate.fromString("0001-01-01", 'yyyy-MM-dd'))
-    date_time_widget.setDisplayFormat.assert_called_once_with('yyyy-MM-dd')
-
-  # Parametrized test for error cases
-  @pytest.mark.parametrize("meta_field, test_id", [
-    ({"typeClass": "primitive", "multiple": False}, "error_primitive_multiple_false"),
-    ({"typeClass": "unknown"}, "error_unknown_typeclass"),
-    # Add more test cases for different error scenarios
-  ])
-  def test_add_new_entry_error_cases(self, primitive_compound_frame, meta_field, test_id):
-    # Arrange
-    primitive_compound_frame.meta_field = meta_field
-
-    # Act
-    primitive_compound_frame.add_button_click_handler()
-
-    # Assert
-    assert primitive_compound_frame.logger.error.called
-
-  # Parametrized test cases
-  @pytest.mark.parametrize("meta_field,expected_log,expected_error", [
-    # ID: HappyPath-Primitive
-    ({"typeName": "testType", "typeClass": "primitive", "multiple": True, "valueTemplate": [{"key": "value"}]},
-     ('Adding new entry of type %s, name: %s', 'primitive', 'testType'), None),
-    # ID: HappyPath-Compound
-    ({"typeName": "testType", "typeClass": "compound", "multiple": True,
-      "valueTemplate": [
-        {"key1": {"typeName": "date", "value": "2023-01-01"}, "key2": {"typeName": "title", "value": "2023-01-01"}}]},
-     ('Adding new entry of type %s, name: %s', 'compound', 'testType'), None),
-    # ID: ErrorCase-NonMultiple
-    ({"typeName": "testType", "typeClass": "primitive", "multiple": False, "valueTemplate": [{"key": "value"}]},
-     None, "Add operation not supported for non-multiple entries"),
-    # ID: ErrorCase-UnknownTypeClass
-    ({"typeName": "testType", "typeClass": "unknown", "multiple": True, "valueTemplate": [{"key": "value"}]},
-     None, ('Unknown type class: %s', 'unknown')),
-  ], ids=["SuccessCase-Primitive", "SuccessCase-Compound", "ErrorCase-NonMultiple", "ErrorCase-UnknownTypeClass"])
-  def test_add_new_entry(self, mocker, primitive_compound_frame, meta_field, expected_log, expected_error):
-    mocker.resetall()
-    primitive_compound_frame.meta_field = meta_field
-    mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.populate_primitive_horizontal_layout')
-    mock_qvbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QVBoxLayout')
-    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QHBoxLayout')
-    create_date_time_widget = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_date_time_widget')
-    create_line_edit = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_line_edit')
-    add_delete_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_delete_button')
-    add_clear_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_clear_button')
-
-    # Act
-    primitive_compound_frame.add_button_click_handler()
-
-    # Assert
-    if meta_field['typeClass'] == "primitive" and not expected_error:
-      primitive_compound_frame.mainVerticalLayout.findChild.assert_called_once_with(
-        mock_qvbox_layout,
-        "primitiveVerticalLayout"
-      )
-      primitive_compound_frame.populate_primitive_horizontal_layout.assert_called_once_with(
-        primitive_compound_frame.mainVerticalLayout.findChild.return_value,
-        meta_field['typeName'],
-        "",
-        meta_field['valueTemplate'][0]
-      )
-    elif meta_field['typeClass'] == "compound" and not expected_error:
-      mock_qhbox_layout.assert_called_once()
-      mock_qhbox_layout.return_value.setObjectName.assert_called_once_with("compoundHorizontalLayout")
-      create_date_time_widget.assert_called_once()
-      create_line_edit.assert_called_once()
-      add_clear_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value)
-      add_delete_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value)
-      primitive_compound_frame.mainVerticalLayout.addLayout.assert_called_once_with(mock_qhbox_layout.return_value)
-      mock_qhbox_layout.return_value.addWidget.assert_has_calls(
-        [mocker.call(create_date_time_widget.return_value), mocker.call(create_line_edit.return_value)])
-    if expected_log:
-      primitive_compound_frame.logger.info.assert_called_with(expected_log[0], expected_log[1], expected_log[2])
-    if expected_error:
-      if isinstance(expected_error, tuple):
-        primitive_compound_frame.logger.error.assert_called_with(*expected_error)
-      else:
-        primitive_compound_frame.logger.error.assert_called_with(expected_error)
-
-  # Parametrized test cases
-  @pytest.mark.parametrize(
-    "test_id, compound_entry, template_entry, is_date_time_type_return, expected_widget_calls",
-    [
-      # Success path tests with various realistic test values
-      ("SuccessCase-1",
-       {"date": {"value": "2021-01-01"}},
-       {"date": {"value": "2020-01-01"}},
-       True,
-       [('create_date_time_widget', 1), ('create_line_edit', 0)]),
-      ("SuccessCase-2",
-       {"text": {"value": "Sample Text"}},
-       {"text": {"value": "Default Text"}},
-       False,
-       [('create_date_time_widget', 0), ('create_line_edit', 1)]),
-      # Edge cases
-      ("EdgeCase-1",
-       {},
-       {},
-       False,
-       []),
-
-      # Error cases
-      # Assuming that an error case would be when template_entry is missing a key present in compound_entry
-      ("ErrorCase-1",
-       {"date": {"value": "2021-01-01"}},
-       {},
-       True,
-       [('create_date_time_widget', 1)]),  # KeyError should be raised when template_entry is missing
-    ]
-  )
-  def test_populate_compound_entry(self, mocker, primitive_compound_frame, test_id, compound_entry, template_entry,
-                                   is_date_time_type_return,
-                                   expected_widget_calls):
-    # Arrange
-    mocker.resetall()
-    is_date_time_type = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.is_date_time_type',
-                                     return_value=is_date_time_type_return)
-    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QHBoxLayout')
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_date_time_widget')
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_line_edit')
-    mock_add_delete_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_delete_button')
-    mock_add_clear_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_clear_button')
-    mock_qhbox_layout.return_value.count.return_value = len(compound_entry)
-
-    # Act
-    primitive_compound_frame.populate_compound_entry(compound_entry, template_entry)
-
-    # Assert
-    for widget_name, call_count in expected_widget_calls:
-      assert getattr(primitive_compound_frame, widget_name).call_count == call_count
-    if test_id == "EdgeCase-1":
-      mock_add_delete_button.assert_not_called()
-    if compound_entry:
-      is_date_time_type.assert_called_once()
-      mock_add_delete_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value,
-                                                     True)
-      mock_add_clear_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value)
-      mock_qhbox_layout.return_value.addWidget.assert_has_calls(
-        [mocker.call(primitive_compound_frame.create_date_time_widget.return_value) if is_date_time_type_return else
-         mocker.call(primitive_compound_frame.create_line_edit.return_value)]
-      )
-      primitive_compound_frame.mainVerticalLayout.addLayout.assert_called_once_with(mock_qhbox_layout.return_value)
-
-  @pytest.mark.parametrize(
-    "meta_field, expected_calls, test_id",
-    [
-      # Happy path tests
-      (
-          {'value': ['val1', 'val2'], 'typeName': 'String', 'valueTemplate': ['tmpl'], 'multiple': True},
-          2,
-          "happy_path_multiple_values"
-      ),
-      (
-          {'value': 'single_val', 'typeName': 'Number', 'valueTemplate': 'tmpl', 'multiple': False},
-          1,
-          "happy_path_single_value"
-      ),
-      # Edge cases
-      (
-          {'value': [], 'typeName': 'String', 'valueTemplate': ['tmpl'], 'multiple': True},
-          1,
-          "edge_case_empty_value_list"
-      ),
-      (
-          {'value': '', 'typeName': 'Number', 'valueTemplate': 'tmpl', 'multiple': False},
-          1,
-          "edge_case_empty_string_value"
-      ),
-      # Error cases
-      (
-          {'value': None, 'typeName': 'Number', 'valueTemplate': 'tmpl', 'multiple': False},
-          1,
-          "error_case_none_value"
-      ),
-      (
-          {'value': 'single_val', 'typeName': None, 'valueTemplate': 'tmpl', 'multiple': False},
-          1,
-          "error_case_none_type_name"
-      ),
-    ],
-  )
-  def test_populate_primitive_entry(self, mocker, primitive_compound_frame, meta_field, expected_calls, test_id):
-    # Arrange
-    mocker.resetall()
-    primitive_compound_frame.meta_field = meta_field
-    mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.populate_primitive_horizontal_layout')
-    mock_qvbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QVBoxLayout')
-    # Act
-    primitive_compound_frame.populate_primitive_entry()
-
-    # Assert
-    mock_qvbox_layout.assert_called_once()
-    mock_qvbox_layout.return_value.setObjectName.assert_called_once_with('primitiveVerticalLayout')
-    assert primitive_compound_frame.populate_primitive_horizontal_layout.call_count == expected_calls
-    if expected_calls > 0:
-      primitive_compound_frame.mainVerticalLayout.addLayout.assert_called_once_with(mock_qvbox_layout.return_value)
-    primitive_compound_frame.logger.info.assert_called_with(
-      "Populating new entry of type primitive, name: %s", meta_field.get('typeName')
+    mock_setup_ui.assert_called_once_with(mock_qframe.return_value)
+    mock_metadata_frame_init.assert_called_once_with(mock_qframe.return_value)
+    mock_data_type_class_context.assert_called_once_with(frame.mainVerticalLayout, frame.addPushButton, frame.instance,
+                                                         meta_field)
+    mock_data_type_class_factory.assert_called_once_with(mock_data_type_class_context.return_value)
+    mock_logger.assert_called_once_with('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame')
+    mock_qframe.assert_called_once()
+    assert frame.meta_field == meta_field
+    frame.data_type_class_factory.make_data_type_class.assert_called_once_with(
+      DataTypeClassName(meta_field['typeClass'])
     )
+    frame.addPushButton.clicked.connect.assert_called_once_with(frame.add_button_click_handler)
+    frame.load_ui.assert_called_once()
 
-  # Parametrized test cases
-  # Parametrized test cases
-  @pytest.mark.parametrize("type_name,type_value,type_value_template,is_date_time", [
-    # Test ID: #1 - Happy path, date time type
-    ("date", "2021-01-01T00:00:00", "YYYY-MM-DDTHH:MM:SS", True),
-    # Test ID: #2 - Happy path, non-date time type
-    ("text", "example", "{template}", False),
-    # Add more test cases for edge and error cases
-  ])
-  def test_populate_primitive_horizontal_layout(self, mocker, type_name, primitive_compound_frame, type_value,
-                                                type_value_template, is_date_time):
+  @pytest.mark.parametrize("meta_field, expected_error", [
+    ({}, KeyError),
+    ({"typeClass": ""}, ValueError),
+    ({"typeClass": None}, ValueError),
+  ], ids=["empty_meta_field", "empty_type_class", "none_type_class"])
+  def test_primitive_compound_frame_initialization_edge_cases(self, mocker, mock_logger, mock_data_type_class_factory,
+                                                              mock_data_type_class, mock_qframe, meta_field,
+                                                              expected_error):
     # Arrange
-    mock_layout = mocker.MagicMock(spec=QBoxLayout)
-    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QHBoxLayout')
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_date_time_widget')
-    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.create_line_edit')
-    mock_add_delete_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_delete_button')
-    mock_add_clear_button = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.add_clear_button')
-    is_date_time_type_mock = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.is_date_time_type',
-                                          return_value=is_date_time)
+    mocker.patch(
+      "pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi")
+    mocker.patch(
+      "pasta_eln.GUI.dataverse.metadata_frame_base.MetadataFrame.__init__")
+    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.DataTypeClassContext',
+                 MagicMock(spec=DataTypeClassContext))
+    mocker.patch.object(PrimitiveCompoundFrame, 'addPushButton', MagicMock(spec=QPushButton), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'mainVerticalLayout', MagicMock(spec=QVBoxLayout), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'load_ui')
 
     # Act
-    primitive_compound_frame.populate_primitive_horizontal_layout(mock_layout, type_name, type_value,
-                                                                  type_value_template)
+    with pytest.raises(expected_error):
+      PrimitiveCompoundFrame(meta_field)
 
-    # Assert
-    is_date_time_type_mock.assert_called_once_with(type_name)
-    mock_qhbox_layout.return_value.setObjectName.assert_called_once_with('primitiveHorizontalLayout')
-    if is_date_time:
-      primitive_compound_frame.create_date_time_widget.assert_called_once_with(type_name, type_value,
-                                                                               type_value_template)
-      mock_qhbox_layout.return_value.addWidget.assert_has_calls(
-        primitive_compound_frame.create_date_time_widget.return_value)
-    else:
-      primitive_compound_frame.create_line_edit.assert_called_once_with(type_name, type_value, type_value_template)
-      mock_qhbox_layout.return_value.addWidget.assert_has_calls(
-        primitive_compound_frame.create_line_edit.return_value)
-    mock_add_delete_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value,
-                                                   True)
-    mock_add_clear_button.assert_called_once_with(primitive_compound_frame.instance, mock_qhbox_layout.return_value)
-    mock_layout.addLayout.assert_called_once_with(mock_qhbox_layout.return_value)
-
-  @pytest.mark.parametrize("type_class, multiple, expected_value, test_id", [
-    # Success path tests
-    ("primitive", False, "single_value", "success_single_primitive"),
-    ("primitive", True, ["value1", "value2"], "success_multiple_primitive"),
-    ("compound", False, {"key": "value"}, "success_single_compound"),
-    ("compound", True, [{"key1": "value1"}, {"key2": "value2"}], "success_multiple_compound"),
-
-    # Edge cases
-    ("primitive", True, [], "edge_no_values_primitive"),
-    ("compound", True, [], "edge_no_values_compound"),
-
-    # Error cases
-    ("unsupported", False, None, "error_unsupported_type_class"),
-  ])
-  def test_save_modifications(self, type_class, mocker, primitive_compound_frame, multiple, expected_value, test_id):
+  @pytest.mark.parametrize("meta_field", [
+    ({"typeClass": "InvalidTypeClass"}),
+  ], ids=["invalid_type_class"])
+  def test_primitive_compound_frame_initialization_error_cases(self, mocker, mock_logger, mock_data_type_class_factory,
+                                                               mock_data_type_class, mock_qframe, meta_field):
     # Arrange
-    mock_qvbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QVBoxLayout')
-    mock_qhbox_layout = mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.QHBoxLayout')
-    mock_save_compound_horizontal_layout_values = mocker.patch(
-      'pasta_eln.GUI.dataverse.primitive_compound_frame.PrimitiveCompoundFrame.save_compound_horizontal_layout_values')
-    mocker.resetall()
-    primitive_compound_frame.meta_field = {
-      'typeName': 'testTypeName',
-      'typeClass': type_class,
-      'multiple': multiple,
-      'value': ["test"] if multiple else "",
-      'valueTemplate': ["test"] if multiple else ""
-    }
-    primitive_compound_frame.mainVerticalLayout.findChild.return_value.count.return_value = 1 if multiple else 0
-    primitive_compound_frame.mainVerticalLayout.count.return_value = 1 if multiple else 0
-
+    mocker.patch(
+      "pasta_eln.GUI.dataverse.primitive_compound_controlled_frame_base.Ui_PrimitiveCompoundControlledFrameBase.setupUi")
+    mocker.patch(
+      "pasta_eln.GUI.dataverse.metadata_frame_base.MetadataFrame.__init__")
+    mocker.patch('pasta_eln.GUI.dataverse.primitive_compound_frame.DataTypeClassContext',
+                 MagicMock(spec=DataTypeClassContext))
+    mocker.patch.object(PrimitiveCompoundFrame, 'addPushButton', MagicMock(spec=QPushButton), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'mainVerticalLayout', MagicMock(spec=QVBoxLayout), create=True)
+    mocker.patch.object(PrimitiveCompoundFrame, 'load_ui')
     # Act
-    primitive_compound_frame.save_modifications()
+    with pytest.raises(ValueError):
+      PrimitiveCompoundFrame(meta_field)
 
-    # Assert
-    if type_class == "unsupported":
-      primitive_compound_frame.logger.error.assert_called_once_with("Unsupported typeClass: %s",
-                                                                    primitive_compound_frame.meta_field.get(
-                                                                      'typeClass'))
-    else:
-      if type_class == "primitive":
-        primitive_compound_frame.mainVerticalLayout.findChild.assert_called_once_with(mock_qvbox_layout,
-                                                                                      "primitiveVerticalLayout")
-        if multiple:
-          primitive_compound_frame.mainVerticalLayout.findChild.return_value.count.assert_called_once()
-          assert (primitive_compound_frame.meta_field['value'] ==
-                  [primitive_compound_frame.mainVerticalLayout.findChild.return_value.itemAt.return_value.
-                  itemAt.return_value.widget.return_value.text.return_value])
-        else:
-          assert (primitive_compound_frame.meta_field[
-                    'value'] == primitive_compound_frame.mainVerticalLayout.findChild.return_value
-                  .itemAt.return_value.itemAt.return_value.widget.return_value.text.return_value)
-      elif type_class == "compound":
-        if multiple:
-          primitive_compound_frame.mainVerticalLayout.count.assert_called_once()
-          primitive_compound_frame.mainVerticalLayout.itemAt.assert_called_once_with(0)
-          mock_save_compound_horizontal_layout_values.assert_called_once_with(
-            primitive_compound_frame.mainVerticalLayout.itemAt.return_value,
-            primitive_compound_frame.meta_field.get('valueTemplate')[0]
-          )
-        else:
-          primitive_compound_frame.mainVerticalLayout.findChild.assert_called_once_with(mock_qhbox_layout,
-                                                                                        "compoundHorizontalLayout")
-          mock_save_compound_horizontal_layout_values.assert_called_once_with(
-            primitive_compound_frame.mainVerticalLayout.findChild.return_value,
-            primitive_compound_frame.meta_field.get('valueTemplate') or {}
-          )
-
-      primitive_compound_frame.logger.info.assert_called_once_with(
-        "Saving changes to meta_field for type, name: %s, class: %s",
-        primitive_compound_frame.meta_field.get('typeName'),
-        primitive_compound_frame.meta_field.get('typeClass'))
-
-  # Parametrized test cases
   @pytest.mark.parametrize(
-    "test_id, layout_widgets, value_template, expected_meta_field_value",
+    "meta_field, expected_log_message",
     [
-      # Happy path tests with various realistic test values
-      ("success-1", [("name1", "value1"), ("name2", "value2")], {"name1": {}, "name2": {}},
-       [{"name1": {"value": "value1"}, "name2": {"value": "value2"}}]),
-      ("success-2", [("name3", ""), ("name4", "value4")], {"name3": {}, "name4": {}},
-       [{"name3": {"value": ""}, "name4": {"value": "value4"}}]),
-
-      # Edge cases
-      ("edge-1", [], {"name1": {}}, []),  # No widgets in layout
-      ("edge-2", [("name1", None)], {"name1": {}}, []),  # Widget text is None
-    ]
+      ({"typeClass": "primitive", "multiple": False, "value": "test_value"},
+       "Loading UI for {'typeClass': 'primitive', 'multiple': False, 'value': 'test_value'}"),
+      ({"typeClass": "compound", "multiple": True, "value": []},
+       "Loading UI for {'typeClass': 'compound', 'multiple': True, 'value': []}"),
+      ({"typeClass": "unknown", "multiple": False, "value": None},
+       "Loading UI for {'typeClass': 'unknown', 'multiple': False, 'value': None}")
+    ],
+    ids=["primitive_single", "compound_multiple_empty", "unknown_type"]
   )
-  def test_save_compound_horizontal_layout_values(self, mocker, primitive_compound_frame, test_id, layout_widgets,
-                                                  value_template, expected_meta_field_value):
+  def test_load_ui(self, mock_primitive_compound_frame, meta_field, expected_log_message):
     # Arrange
-    mocker.resetall()
-    primitive_compound_frame.meta_field = {'value': []}
-
-    compound_horizontal_layout = mocker.MagicMock(spec=QBoxLayout)
-    compound_horizontal_layout.count.return_value = len(layout_widgets)
-    # Create mock widgets and add them to the layout
-    compound_horizontal_layout.itemAt = lambda pos, _widgets=layout_widgets: create_mock_line_edit(mocker, *_widgets[
-      pos]) if pos < len(_widgets) else None
+    mock_primitive_compound_frame.logger.reset_mock()
+    mock_primitive_compound_frame.data_type.reset_mock()
+    mock_primitive_compound_frame.meta_field = meta_field
 
     # Act
-    primitive_compound_frame.save_compound_horizontal_layout_values(compound_horizontal_layout, value_template)
+    mock_primitive_compound_frame.load_ui()
 
     # Assert
-    assert primitive_compound_frame.meta_field['value'] == expected_meta_field_value
+    mock_primitive_compound_frame.logger.info.assert_called_once_with("Loading UI for %s", meta_field)
+    mock_primitive_compound_frame.data_type.populate_entry.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_log_message",
+    [
+      ({"typeClass": "primitive", "multiple": True, "typeName": "test_name"},
+       "Adding new entry of type primitive, name: test_name"),
+      ({"typeClass": "compound", "multiple": False, "typeName": "test_name"},
+       "Adding new entry of type compound, name: test_name"),
+      ({"typeClass": "unknown", "multiple": True, "typeName": "test_name"},
+       "Adding new entry of type unknown, name: test_name")
+    ],
+    ids=["primitive_multiple", "compound_single", "unknown_type"]
+  )
+  def test_add_button_click_handler(self, mock_primitive_compound_frame, meta_field, expected_log_message):
+    # Arrange
+    mock_primitive_compound_frame.meta_field = meta_field
+
+    # Act
+    mock_primitive_compound_frame.add_button_click_handler()
+
+    # Assert
+    mock_primitive_compound_frame.logger.info.assert_called_with("Adding new entry of type %s, name: %s",
+                                                                 meta_field.get('typeClass', ''),
+                                                                 meta_field.get('typeName', ''))
+    if not meta_field.get('multiple'):
+      mock_primitive_compound_frame.logger.error.assert_called_with(
+        "Add operation not supported for non-multiple entries")
+    else:
+      mock_primitive_compound_frame.data_type.add_new_entry.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_log_message",
+    [
+      ({"typeClass": "primitive", "typeName": "test_name"},
+       "Saving changes to meta_field for type, name: test_name, class: primitive"),
+      ({"typeClass": "compound", "typeName": "test_name"},
+       "Saving changes to meta_field for type, name: test_name, class: compound"),
+      ({"typeClass": "unknown", "typeName": "test_name"},
+       "Saving changes to meta_field for type, name: test_name, class: unknown")
+    ],
+    ids=["primitive", "compound", "unknown_type"]
+  )
+  def test_save_modifications(self, mock_primitive_compound_frame, meta_field, expected_log_message):
+    # Arrange
+    mock_primitive_compound_frame.meta_field = meta_field
+
+    # Act
+    mock_primitive_compound_frame.save_modifications()
+
+    # Assert
+    mock_primitive_compound_frame.logger.info.assert_called_with(
+      "Saving changes to meta_field for type, name: %s, class: %s", meta_field.get('typeName'),
+      meta_field.get('typeClass'))
+    mock_primitive_compound_frame.data_type.save_modifications.assert_called_once()

--- a/tests/unit_tests/test_dataverse_primitive_compound_frame.py
+++ b/tests/unit_tests/test_dataverse_primitive_compound_frame.py
@@ -154,7 +154,7 @@ class TestDataversePrimitiveCompoundFrame:
     primitive_compound_frame.logger.error = mocker.MagicMock()
 
     # Act
-    primitive_compound_frame.add_new_entry()
+    primitive_compound_frame.add_button_click_handler()
     # Assert
     if isinstance(expected_error_log, str):
       primitive_compound_frame.logger.error.assert_called_with(expected_error_log)
@@ -294,7 +294,7 @@ class TestDataversePrimitiveCompoundFrame:
     primitive_compound_frame.meta_field = meta_field
 
     # Act
-    primitive_compound_frame.add_new_entry()
+    primitive_compound_frame.add_button_click_handler()
 
     # Assert
     assert primitive_compound_frame.logger.error.called
@@ -333,7 +333,7 @@ class TestDataversePrimitiveCompoundFrame:
       'pasta_eln.GUI.dataverse.primitive_compound_frame.add_clear_button')
 
     # Act
-    primitive_compound_frame.add_new_entry()
+    primitive_compound_frame.add_button_click_handler()
 
     # Assert
     if meta_field['typeClass'] == "primitive" and not expected_error:

--- a/tests/unit_tests/test_dataverse_primitive_data_type_class.py
+++ b/tests/unit_tests/test_dataverse_primitive_data_type_class.py
@@ -1,0 +1,365 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_primitive_data_type_class.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QBoxLayout, QFrame, QPushButton, QVBoxLayout
+from _pytest.mark import param
+
+from pasta_eln.GUI.dataverse.data_type_class_context import DataTypeClassContext
+from pasta_eln.GUI.dataverse.primitive_data_type_class import PrimitiveDataTypeClass
+
+
+@pytest.fixture
+def data_context():
+  context = MagicMock(spec=DataTypeClassContext)
+  context.main_vertical_layout = MagicMock(spec=QVBoxLayout)
+  context.meta_field = {
+    'typeName': 'testType',
+    'value': 'testValue',
+    'valueTemplate': ['templateValue'],
+    'multiple': False
+  }
+  context.add_push_button = MagicMock(spec=QPushButton)
+  context.parent_frame = MagicMock(spec=QFrame)
+  return context
+
+
+@pytest.fixture
+def mock_primitive_data_type_class(mocker, data_context):
+  mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.logging.getLogger")
+  return PrimitiveDataTypeClass(data_context)
+
+
+class TestPrimitiveDataTypeClass:
+
+  def test_init_success(self, mocker, data_context):
+    # Arrange
+    mock_get_logger = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.logging.getLogger")
+    # Act
+    instance = PrimitiveDataTypeClass(data_context)
+
+    # Assert
+    mock_get_logger.assert_called_with("pasta_eln.GUI.dataverse.primitive_data_type_class.PrimitiveDataTypeClass")
+    assert isinstance(instance, PrimitiveDataTypeClass)
+    assert instance.context == data_context
+    assert instance.logger == mock_get_logger.return_value
+
+  @pytest.mark.parametrize(
+    "context, expected_exception",
+    [
+      (None, TypeError),
+      # Add more edge cases if needed
+    ],
+    ids=[
+      "none_context",
+      # Add more unique IDs for each test case
+    ]
+  )
+  def test_init_edge_cases(self, context, expected_exception):
+    # Act and Assert
+    with pytest.raises(expected_exception):
+      PrimitiveDataTypeClass(context)
+
+  @pytest.mark.parametrize(
+    "context, expected_exception",
+    [
+      ("invalid_context", TypeError),
+      # Add more error cases if needed
+    ],
+    ids=[
+      "string_context",
+      # Add more unique IDs for each test case
+    ]
+  )
+  def test_init_error_cases(self, context, expected_exception):
+    # Act and Assert
+    with pytest.raises(expected_exception):
+      PrimitiveDataTypeClass(context)
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_calls",
+    [
+      # Success path with single value
+      (
+          {'value': 'test_value', 'typeName': 'test_type', 'valueTemplate': 'template'},
+          [("test_type", "test_value", "template", False)]
+      ),
+      # Success path with multiple values
+      (
+          {'value': ['value1', 'value2'], 'typeName': 'test_type', 'valueTemplate': ['template1', 'template2'],
+           'multiple': True},
+          [("test_type", "value1", "template1"), ("test_type", "value2", "template1")]
+      ),
+      # Edge case with empty value list
+      (
+          {'value': [], 'typeName': 'test_type', 'valueTemplate': ['template1'], 'multiple': True},
+          [("test_type", "", "template1")]
+      ),
+      # Edge case with no valueTemplate
+      (
+          {'value': 'test_value', 'typeName': 'test_type'},
+          [("test_type", "test_value", "", False)]
+      ),
+      # Error case with non-list value for multiple
+      (
+          {'value': 'test_value', 'typeName': 'test_type', 'valueTemplate': 'template', 'multiple': True},
+          [("test_type", "test_value", "template", False)]
+      ),
+    ],
+    ids=[
+      "single_value",
+      "multiple_values",
+      "empty_value_list",
+      "no_value_template",
+      "non_list_value_for_multiple"
+    ]
+  )
+  def test_populate_primitive_entry(self, mocker, mock_primitive_data_type_class, meta_field, expected_calls):
+    # Arrange
+    mock_primitive_data_type_class.populate_primitive_horizontal_layout = MagicMock()
+    mock_qv_box_layout = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.QVBoxLayout")
+    mock_primitive_data_type_class.context.meta_field = meta_field
+
+    # Act
+    mock_primitive_data_type_class.populate_primitive_entry()
+
+    # Assert
+    mock_primitive_data_type_class.logger.info.assert_called_once_with(
+      "Populating new entry of type primitive, name: %s", meta_field.get('typeName'))
+    mock_qv_box_layout.assert_called_once()
+    mock_qv_box_layout.return_value.setObjectName.assert_called_once_with("primitiveVerticalLayout")
+    assert mock_primitive_data_type_class.populate_primitive_horizontal_layout.call_count == len(expected_calls)
+    for call, expected in zip(mock_primitive_data_type_class.populate_primitive_horizontal_layout.call_args_list,
+                              expected_calls):
+      expected = (mock_qv_box_layout.return_value,) + expected
+      mock_primitive_data_type_class.populate_primitive_horizontal_layout.assert_any_call(*expected)
+    mock_primitive_data_type_class.context.main_vertical_layout.addLayout.assert_called_once_with(
+      mock_qv_box_layout.return_value)
+
+  @pytest.mark.parametrize("meta_field, widget_texts, expected_value", [
+    # Happy path: single value
+    ({"typeName": "testType", "typeClass": "testClass", "multiple": False, "value": []}, ["Test Value"], "Test Value"),
+    # Happy path: multiple values
+    ({"typeName": "testType", "typeClass": "testClass", "multiple": True, "value": []}, ["Value 1", "Value 2"],
+     ["Value 1", "Value 2"]),
+    # Edge case: single value with "No Value"
+    ({"typeName": "testType", "typeClass": "testClass", "multiple": False, "value": []}, ["No Value"], ""),
+    # Edge case: multiple values with "No Value"
+    ({"typeName": "testType", "typeClass": "testClass", "multiple": True, "value": []}, ["No Value", "Value 2"],
+     ["Value 2"]),
+    # Error case: primitive_vertical_layout is None
+    ({"typeName": "testType", "typeClass": "testClass", "multiple": False, "value": []}, None, None),
+  ], ids=[
+    "single_value",
+    "multiple_values",
+    "single_value_no_value",
+    "multiple_values_with_no_value",
+    "primitive_vertical_layout_none"
+  ])
+  def test_save_modifications(self, mocker, mock_primitive_data_type_class, data_context, meta_field, widget_texts,
+                              expected_value):
+    # Arrange
+    mock_get_primitive_line_edit_text_value = mocker.patch(
+      "pasta_eln.GUI.dataverse.primitive_data_type_class.get_primitive_line_edit_text_value")
+    data_context.meta_field = meta_field
+    primitive_vertical_layout = MagicMock(spec=QVBoxLayout) if widget_texts is not None else None
+    if primitive_vertical_layout:
+      primitive_vertical_layout.count.return_value = len(widget_texts)
+      mock_get_primitive_line_edit_text_value.side_effect = widget_texts
+      data_context.main_vertical_layout.findChild.return_value = primitive_vertical_layout
+    else:
+      data_context.main_vertical_layout.findChild.return_value = None
+
+    # Act
+    mock_primitive_data_type_class.save_modifications()
+
+    # Assert
+    mock_primitive_data_type_class.context.main_vertical_layout.findChild.assert_called_once_with(QVBoxLayout,
+                                                                                                  "primitiveVerticalLayout")
+    if widget_texts is not None:
+      if meta_field['multiple']:
+        primitive_vertical_layout.count.assert_called_once()
+        assert data_context.meta_field['value'] == expected_value
+      else:
+        assert data_context.meta_field['value'] == expected_value
+    else:
+      assert data_context.meta_field['value'] == []
+      if primitive_vertical_layout:
+        primitive_vertical_layout.logger.error.assert_called_once_with("Failed to find primitiveVerticalLayout!")
+
+  @pytest.mark.parametrize(
+    "layout_exists, layout_type, value_template, type_name, expected_log_call",
+    [
+      # Happy path tests
+      (True, QVBoxLayout, ["template1"], "type1", None),
+      (True, QVBoxLayout, ["template2"], "type2", None),
+
+      # Edge cases
+      (True, QVBoxLayout, [""], "", None),
+      (True, QVBoxLayout, [], "", None),
+
+      # Error cases
+      (False, QVBoxLayout, ["template1"], "type1", "Failed to find primitiveVerticalLayout!"),
+      (True, QBoxLayout, ["template1"], "type1", "Failed to find primitiveVerticalLayout!"),
+    ],
+    ids=[
+      "happy_path_template1_type1",
+      "happy_path_template2_type2",
+      "edge_case_empty_template_empty_type",
+      "edge_case_no_template_empty_type",
+      "error_case_layout_not_found",
+      "error_case_wrong_layout_type",
+    ]
+  )
+  def test_add_new_entry(self, mock_primitive_data_type_class, layout_exists, layout_type, value_template, type_name,
+                         expected_log_call):
+
+    # Arrange
+    mock_primitive_data_type_class.populate_primitive_horizontal_layout = MagicMock()
+    if layout_exists:
+      layout = MagicMock(spec=layout_type)
+      mock_primitive_data_type_class.context.main_vertical_layout.findChild.return_value = layout
+    else:
+      mock_primitive_data_type_class.context.main_vertical_layout.findChild.return_value = None
+    mock_primitive_data_type_class.context.meta_field = {'valueTemplate': value_template, 'typeName': type_name}
+
+    # Act
+    mock_primitive_data_type_class.add_new_entry()
+
+    # Assert
+    if expected_log_call:
+      mock_primitive_data_type_class.logger.error.assert_called_once_with(expected_log_call)
+      mock_primitive_data_type_class.populate_primitive_horizontal_layout.assert_not_called()
+    else:
+      mock_primitive_data_type_class.logger.error.assert_not_called()
+      mock_primitive_data_type_class.populate_primitive_horizontal_layout.assert_called_once_with(
+        mock_primitive_data_type_class.context.main_vertical_layout.findChild.return_value,
+        type_name,
+        "",
+        value_template[0] if value_template else ""
+      )
+
+  @pytest.mark.parametrize(
+    "meta_field, expected_disabled",
+    [
+      param({"multiple": False}, True, id="multiple_false"),
+      param({"multiple": True}, False, id="multiple_true"),
+      param({}, True, id="multiple_missing"),
+    ],
+    ids=lambda x: x[-1]
+  )
+  def test_populate_entry(self, mock_primitive_data_type_class, meta_field, expected_disabled):
+    # Arrange
+    mock_primitive_data_type_class.populate_primitive_entry = MagicMock()
+    mock_primitive_data_type_class.context.meta_field = meta_field
+
+    # Act
+    mock_primitive_data_type_class.populate_entry()
+
+    # Assert
+    if meta_field.get('multiple'):
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_not_called()
+    else:
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_called_once_with(expected_disabled)
+    mock_primitive_data_type_class.populate_primitive_entry.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "meta_field",
+    [
+      param({"multiple": None}, id="multiple_none"),
+      param({"multiple": "unexpected_string"}, id="multiple_unexpected_string"),
+    ],
+    ids=lambda param: param[-1]
+  )
+  def test_populate_entry_edge_cases(self, mock_primitive_data_type_class, meta_field):
+    # Arrange
+    mock_primitive_data_type_class.populate_primitive_entry = MagicMock()
+    mock_primitive_data_type_class.context.meta_field = meta_field
+
+    # Act
+    mock_primitive_data_type_class.populate_entry()
+
+    # Assert
+    if meta_field.get('multiple'):
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_not_called()
+    else:
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_called_once_with(True)
+    mock_primitive_data_type_class.populate_primitive_entry.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "meta_field",
+    [
+      param({"multiple": 123}, id="multiple_integer"),
+      param({"multiple": []}, id="multiple_list"),
+      param({"multiple": {}}, id="multiple_dict"),
+    ],
+    ids=lambda param: param[-1]
+  )
+  def test_populate_entry_error_cases(self, mock_primitive_data_type_class, meta_field):
+    # Arrange
+    mock_primitive_data_type_class.populate_primitive_entry = MagicMock()
+    mock_primitive_data_type_class.context.meta_field = meta_field
+
+    # Act
+    mock_primitive_data_type_class.populate_entry()
+
+    # Assert
+    if meta_field.get('multiple'):
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_not_called()
+    else:
+      mock_primitive_data_type_class.context.add_push_button.setDisabled.assert_called_once_with(True)
+    mock_primitive_data_type_class.populate_primitive_entry.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "type_name, type_value, type_value_template, enable_delete_button, expected_widget_type",
+    [
+      param("datetime", "2023-10-01T12:00:00", "2023-10-01T12:00:00", True, "QDateTimeEdit",
+            id="success_path_datetime"),
+      param("string", "test_value", "default_value", True, "QLineEdit", id="success_path_string"),
+      param("datetime", "2023-10-01T12:00:00", "2023-10-01T12:00:00", False, "QDateTimeEdit",
+            id="disable_delete_button"),
+      param("string", "", "", True, "QLineEdit", id="empty_string_value"),
+      param("datetime", "", "", True, "QDateTimeEdit", id="empty_datetime_value"),
+    ],
+    ids=lambda x: x[-1]
+  )
+  def test_populate_primitive_horizontal_layout(self, mocker, mock_primitive_data_type_class, type_name, type_value,
+                                                type_value_template,
+                                                enable_delete_button, expected_widget_type):
+    # Arrange
+    mock_qh_box_layout = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.QHBoxLayout")
+    mock_is_date_time_type = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.is_date_time_type",
+                                          return_value='date' in type_name or 'time' in type_name)
+    mock_create_date_time_widget = mocker.patch(
+      "pasta_eln.GUI.dataverse.primitive_data_type_class.create_date_time_widget")
+    mock_add_clear_button = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.add_clear_button")
+    mock_add_delete_button = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.add_delete_button")
+    mock_create_line_edit = mocker.patch("pasta_eln.GUI.dataverse.primitive_data_type_class.create_line_edit")
+    mock_new_primitive_entry_layout = MagicMock(spec=QBoxLayout)
+
+    # Act
+    mock_primitive_data_type_class.populate_primitive_horizontal_layout(mock_new_primitive_entry_layout,
+                                                                        type_name,
+                                                                        type_value,
+                                                                        type_value_template,
+                                                                        enable_delete_button)
+
+    # Assert
+    mock_qh_box_layout.assert_called_once()
+    mock_qh_box_layout.return_value.setObjectName.assert_called_once_with("primitiveHorizontalLayout")
+    mock_new_primitive_entry_layout.addLayout.assert_called_once_with(mock_qh_box_layout.return_value)
+    mock_is_date_time_type.assert_called_once_with(type_name)
+    mock_qh_box_layout.return_value.addWidget.assert_called_once_with(
+      mock_create_date_time_widget.return_value if mock_is_date_time_type.return_value else mock_create_line_edit.return_value
+    )
+    mock_add_clear_button.assert_called_once_with(mock_primitive_data_type_class.context.parent_frame,
+                                                  mock_qh_box_layout.return_value)
+    mock_add_delete_button.assert_called_once_with(mock_primitive_data_type_class.context.parent_frame,
+                                                   mock_qh_box_layout.return_value, enable_delete_button)

--- a/tests/unit_tests/test_dataverse_utility_functions.py
+++ b/tests/unit_tests/test_dataverse_utility_functions.py
@@ -1,0 +1,209 @@
+#  PASTA-ELN and all its sub-parts are covered by the MIT license.
+#
+#  Copyright (c) 2024
+#
+#  Author: Jithu Murugan
+#  Filename: test_dataverse_utility_functions.py
+#
+#  You should have received a copy of the license with this file. Please refer the license file for more information.
+
+import pytest
+from PySide6.QtCore import QDate
+from PySide6.QtWidgets import QComboBox, QDateTimeEdit, QLineEdit, QVBoxLayout
+
+from pasta_eln.GUI.dataverse.utility_functions import add_clear_button, add_delete_button, clear_layout_widgets, \
+  create_push_button, \
+  delete_layout_and_contents
+
+
+class TestDataverseUtilityFunctions:
+  @pytest.mark.parametrize(
+    "button_display_text, object_name, tooltip, expected_text, expected_object_name, expected_tooltip",
+    [
+      ("Click Me", "btnClickMe", "Click this button",
+       "Click Me", "btnClickMe", "Click this button"),
+      ("Submit", "btnSubmit", "Submit your data", "Submit",
+       "btnSubmit", "Submit your data"),
+      ("Cancel", "btnCancel", "Cancel the operation",
+       "Cancel", "btnCancel", "Cancel the operation"),
+    ],
+    ids=["click_me_button", "submit_button", "cancel_button"]
+  )
+  def test_create_push_button(self, mocker, button_display_text, object_name, tooltip,
+                              expected_text, expected_object_name, expected_tooltip):
+    mock_push_button = mocker.patch('pasta_eln.GUI.dataverse.utility_functions.QPushButton')
+    mock_size_policy = mocker.patch('pasta_eln.GUI.dataverse.utility_functions.QSizePolicy')
+    mock_size = mocker.patch('pasta_eln.GUI.dataverse.utility_functions.QSize')
+    parent_layout = mocker.MagicMock()
+    parent_frame = mocker.MagicMock()
+    clicked_callback = mocker.MagicMock()
+
+    # Act
+    push_button = create_push_button(button_display_text, object_name, tooltip, parent_frame, parent_layout,
+                                     clicked_callback)
+
+    # Assert
+    mock_push_button.assert_called_once_with(parent=parent_frame)
+    push_button.setText.assert_called_once_with(button_display_text)
+    push_button.setObjectName.assert_called_once_with(object_name)
+    push_button.setToolTip.assert_called_once_with(tooltip)
+    mock_size_policy.assert_called_once_with(mock_size_policy.Policy.Fixed, mock_size_policy.Policy.Fixed)
+    size_policy = mock_size_policy.return_value
+    size_policy.setHorizontalStretch.assert_called_once_with(0)
+    size_policy.setVerticalStretch.assert_called_once_with(0)
+    size_policy.setHeightForWidth.assert_called_once_with(
+      mock_push_button.return_value.sizePolicy().hasHeightForWidth())
+    push_button.setSizePolicy.assert_called_once_with(size_policy)
+    mock_size.assert_called_once_with(100, 0)
+    push_button.setMinimumSize.assert_called_once_with(mock_size.return_value)
+    push_button.clicked.connect.assert_called_once()
+
+  @pytest.mark.parametrize(
+    "widget_specs, expected_values",
+    [
+      # Success path tests
+      pytest.param(
+        [QLineEdit, QComboBox, QDateTimeEdit],
+        ["", "No Value", QDate.fromString("01/01/0001", "dd/MM/yyyy")],
+        id="happy_path_all_widgets"
+      ),
+      pytest.param(
+        [QLineEdit],
+        [""],
+        id="happy_path_qlineedit_only"
+      ),
+      pytest.param(
+        [QComboBox],
+        ["No Value"],
+        id="happy_path_qcombobox_only"
+      ),
+      pytest.param(
+        [QDateTimeEdit],
+        [QDate.fromString("01/01/0001", "dd/MM/yyyy")],
+        id="happy_path_qdatetimeedit_only"
+      ),
+      # Edge cases
+      pytest.param(
+        [],
+        [],
+        id="edge_case_empty_layout"
+      ),
+      pytest.param(
+        [None],
+        [None],
+        id="edge_case_none_widget"
+      ),
+      # Error cases
+      pytest.param(
+        [QLineEdit, QComboBox, QDateTimeEdit],
+        None,
+        id="error_case_none_layout"
+      ),
+    ]
+  )
+  def test_clear_layout_widgets(self, mocker, widget_specs, expected_values):
+    # Arrange
+    widgets = [mocker.MagicMock(spec=widget_spec) if widget_spec is not None else None for widget_spec in widget_specs]
+    for widget in widgets:
+      if widget is not None:
+        mocker.patch.object(widget, "widget", create=True)
+        widget.widget.return_value = widget
+    layout = mocker.MagicMock(spec=QVBoxLayout) if expected_values is not None else None
+    if layout:
+      layout.itemAt.side_effect = lambda i: widgets[i] if i < len(widgets) else None
+      layout.count.return_value = len(widgets)
+
+    # Act
+    clear_layout_widgets(layout)
+
+    # Assert
+    if layout:
+      for i, widget in enumerate(widgets):
+        if widget is None:
+          continue
+        elif isinstance(widget, QLineEdit):
+          widget.clear.assert_called_once()
+        elif isinstance(widget, QComboBox):
+          widget.setCurrentText.assert_called_once_with(expected_values[i])
+        elif isinstance(widget, QDateTimeEdit):
+          widget.setDate.assert_called_once_with(expected_values[i])
+    else:
+      for i, widget in enumerate(widgets):
+        if widget is None:
+          continue
+        elif isinstance(widget, QLineEdit):
+          widget.clear.assert_not_called()
+        elif isinstance(widget, QComboBox):
+          widget.setCurrentText.assert_not_called()
+        elif isinstance(widget, QDateTimeEdit):
+          widget.setDate.assert_not_called()
+
+  def test_add_delete_button(self, mocker):
+
+    # Arrange
+    mock_create_push_button = mocker.patch('pasta_eln.GUI.dataverse.utility_functions.create_push_button')
+    parent_layout = mocker.MagicMock()
+    parent_frame = mocker.MagicMock()
+
+    # Act
+    add_delete_button(parent_frame, parent_layout)
+
+    # Assert
+    mock_create_push_button(
+      "Delete",
+      "deletePushButton",
+      "Delete this particular vocabulary entry.",
+      parent_frame,
+      parent_layout,
+      delete_layout_and_contents)
+    parent_layout.addWidget.assert_called_once_with(mock_create_push_button.return_value)
+
+  def test_add_clear_button(self, mocker):
+
+    # Arrange
+    mock_create_push_button = mocker.patch('pasta_eln.GUI.dataverse.utility_functions.create_push_button')
+    parent_layout = mocker.MagicMock()
+    parent_frame = mocker.MagicMock()
+
+    # Act
+    add_clear_button(parent_frame, parent_layout)
+
+    # Assert
+    mock_create_push_button(
+      "Clear",
+      "clearPushButton",
+      "Clear this particular vocabulary entry.",
+      parent_frame,
+      parent_layout,
+      clear_layout_widgets)
+    parent_layout.addWidget.assert_called_once_with(mock_create_push_button.return_value)
+
+  @pytest.mark.parametrize(
+    "test_id, num_widgets",
+    [
+      ("success_path_1_widget", 1),  # ID: success_path_1_widget
+      ("success_path_multiple_widgets", 3),  # ID: success_path_multiple_widgets
+      ("success_path_no_widgets", 0),  # ID: success_path_no_widgets
+      ("edge_case_no_layout", 0),  # ID: edge_case_no_layout
+    ]
+  )
+  def test_delete_layout_and_contents(self, mocker, test_id, num_widgets):
+    # Arrange
+    layout = mocker.MagicMock()
+    widgets = [mocker.MagicMock() for _ in range(num_widgets)]
+    layout.itemAt = lambda pos: widgets[pos]
+    layout.count.return_value = len(widgets)
+    layout = None if test_id == "edge_case_no_layout" else layout
+
+    # Act
+    delete_layout_and_contents(layout)
+
+    # Assert
+    if test_id == "edge_case_no_layout":
+      for widget in widgets:
+        widget.widget.return_value.setParent.assert_not_called()
+    else:
+      layout.count.assert_called_once()
+      layout.setParent.assert_called_once_with(None)
+      for widget in widgets:
+        widget.widget.return_value.setParent.assert_called_once_with(None)

--- a/tests/unit_tests/test_dataverse_utils.py
+++ b/tests/unit_tests/test_dataverse_utils.py
@@ -15,6 +15,7 @@ from typing import Type
 from unittest.mock import AsyncMock, mock_open
 
 import pytest
+from _pytest.mark import param
 from cryptography.fernet import Fernet, InvalidToken
 
 from pasta_eln.dataverse.config_error import ConfigError
@@ -1953,12 +1954,218 @@ class TestDataverseUtils:
      "<html><b style=\"color:Black\">License Metadata:</b><ul><li style=\"color:Gray\">Name: <i>CC BY</i></li><li style=\"color:Gray\">URI: <i>https://creativecommons.org/licenses/by/4.0/</i></li></ul><b style=\"color:Black\">Citation Metadata:</b><ul><b style=\"color:#737373\"><li>Author:</li></b><ul><li style=\"color:Gray\">Item 1:</li><ul><li style=\"color:Gray\">Author Name: <i>John Doe</li></i></ul><li style=\"color:Gray\">Item 2:</li><ul><li style=\"color:Gray\">Author Name: <i>Jane Doe</li></i></ul></ul></ul></html>",
      "complex_nested_metadata")
   ], ids=["success_path_basic_metadata", "edge_case_empty_metadata", "complex_nested_metadata"])
-  def test_get_formatted_metadata_message(self, test_id, metadata, expected_output):
+  def test_get_formatted_metadata_message_version_1(self, test_id, metadata, expected_output):
     # Act
     result = get_formatted_metadata_message(metadata)
 
     # Assert
     assert result == expected_output
+
+  @pytest.mark.parametrize(
+    "metadata, expected_output",
+    [
+      # Success path test case
+      param(
+        {
+          'datasetVersion': {
+            'license': {'name': 'CC0', 'uri': 'https://creativecommons.org/publicdomain/zero/1.0/'},
+            'metadataBlocks': {
+              'citation': {
+                'displayName': 'Citation Metadata',
+                'fields': [
+                  {'typeName': 'title', 'value': 'Test Title', 'multiple': False, 'typeClass': 'primitive'}
+                ]
+              }
+            }
+          }
+        },
+        '<html><b style="color:Black">License Metadata:</b><ul>'
+        '<li style="color:Gray">Name: <i>CC0</i></li>'
+        '<li style="color:Gray">URI: <i>https://creativecommons.org/publicdomain/zero/1.0/</i></li>'
+        '</ul><b style="color:Black">Citation Metadata:</b><ul>'
+        '<b style="color:#737373"><li>Title:</li></b><ul>'
+        '<i style="color:Gray"><li>Test Title</li></i></ul></ul></html>',
+        id="success_path_single_field"
+      ),
+      # Success path test case
+      param(
+        {
+          'datasetVersion': {
+            'license': {'name': 'CC0', 'uri': 'https://creativecommons.org/publicdomain/zero/1.0/'},
+            'metadataBlocks': {
+              'citation': {
+                'displayName': 'Citation Metadata',
+                'fields': [
+                  {'typeName': "coverage.Spectral.Wavelength", 'value': [
+                    {
+                      "coverage.Spectral.MinimumWavelength": {
+                        "typeName": "coverage.Spectral.MinimumWavelength",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "4001"
+                      },
+                      "coverage.Spectral.MaximumWavelength": {
+                        "typeName": "coverage.Spectral.MaximumWavelength",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "4002"
+                      }
+                    },
+                    {
+                      "coverage.Spectral.MinimumWavelength": {
+                        "typeName": "coverage.Spectral.MinimumWavelength",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "4003"
+                      },
+                      "coverage.Spectral.MaximumWavelength": {
+                        "typeName": "coverage.Spectral.MaximumWavelength",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "4004"
+                      }
+                    }
+                  ], 'multiple': True, 'typeClass': 'compound'}
+                ]
+              }
+            }
+          }
+        },
+        '<html><b style="color:Black">License Metadata:</b><ul><li '
+        'style="color:Gray">Name: <i>CC0</i></li><li style="color:Gray">URI: '
+        '<i>https://creativecommons.org/publicdomain/zero/1.0/</i></li></ul><b '
+        'style="color:Black">Citation Metadata:</b><ul><b '
+        'style="color:#737373"><li>Coverage Spectral Wavelength:</li></b><ul><li '
+        'style="color:Gray">Item 1:</li><ul><li style="color:Gray">Coverage Spectral '
+        'Minimum Wavelength: <i>4001</li></i><li style="color:Gray">Coverage Spectral '
+        'Maximum Wavelength: <i>4002</li></i></ul><li style="color:Gray">Item '
+        '2:</li><ul><li style="color:Gray">Coverage Spectral Minimum Wavelength: '
+        '<i>4003</li></i><li style="color:Gray">Coverage Spectral Maximum Wavelength: '
+        '<i>4004</li></i></ul></ul></ul></html>',
+        id="success_path_multiple_compound_field"
+      ),
+      # Success path test case
+      param(
+        {
+          'datasetVersion': {
+            'license': {'name': 'CC0', 'uri': 'https://creativecommons.org/publicdomain/zero/1.0/'},
+            'metadataBlocks': {
+              'citation': {
+                'displayName': 'Citation Metadata',
+                'fields': [
+                  {
+                    "typeName": "targetSampleSize",
+                    "multiple": False,
+                    "typeClass": "compound",
+                    "value": {
+                      "targetSampleActualSize": {
+                        "typeName": "targetSampleActualSize",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "100"
+                      },
+                      "targetSampleSizeFormula": {
+                        "typeName": "targetSampleSizeFormula",
+                        "multiple": False,
+                        "typeClass": "primitive",
+                        "value": "TargetSampleSizeFormula"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        '<html><b style="color:Black">License Metadata:</b><ul><li '
+        'style="color:Gray">Name: <i>CC0</i></li><li style="color:Gray">URI: '
+        '<i>https://creativecommons.org/publicdomain/zero/1.0/</i></li></ul><b '
+        'style="color:Black">Citation Metadata:</b><ul><b '
+        'style="color:#737373"><li>Target Sample Size:</li></b><ul><li '
+        'style="color:Gray">Target Sample Actual Size: <i>100</li></i><li '
+        'style="color:Gray">Target Sample Size Formula: '
+        '<i>TargetSampleSizeFormula</li></i></ul></ul></html>',
+        id="success_path_single_compound_field"
+      ),
+      # Edge case: Empty metadata
+      param(
+        {
+          'datasetVersion': {
+            'license': None,
+            'metadataBlocks': {}
+          }
+        },
+        '<html></html>',
+        id="empty_metadata"
+      ),
+      # Edge case: No license
+      param(
+        {
+          'datasetVersion': {
+            'license': None,
+            'metadataBlocks': {
+              'citation': {
+                'displayName': 'Citation Metadata',
+                'fields': [
+                  {'typeName': 'title', 'value': 'Test Title', 'multiple': False, 'typeClass': 'primitive'}
+                ]
+              }
+            }
+          }
+        },
+        '<html><b style="color:Black">Citation Metadata:</b><ul>'
+        '<b style="color:#737373"><li>Title:</li></b><ul>'
+        '<i style="color:Gray"><li>Test Title</li></i></ul></ul></html>',
+        id="no_license"
+      ),
+      # Edge case: No fields in metadata block
+      param(
+        {
+          'datasetVersion': {
+            'license': {'name': 'CC0', 'uri': 'https://creativecommons.org/publicdomain/zero/1.0/'},
+            'metadataBlocks': {
+              'citation': {
+                'displayName': 'Citation Metadata',
+                'fields': []
+              }
+            }
+          }
+        },
+        '<html><b style="color:Black">License Metadata:</b><ul>'
+        '<li style="color:Gray">Name: <i>CC0</i></li>'
+        '<li style="color:Gray">URI: <i>https://creativecommons.org/publicdomain/zero/1.0/</i></li>'
+        '</ul><b style="color:Black">Citation Metadata:</b><ul>'
+        '<li style="color:#737373">No Value</li></ul></ul></html>',
+        id="no_fields_in_metadata_block"
+      ),
+      # Error case: Missing datasetVersion key
+      param(
+        {},
+        KeyError,
+        id="missing_datasetVersion_key"
+      ),
+      # Error case: Missing metadataBlocks key
+      param(
+        {
+          'datasetVersion': {
+            'license': {'name': 'CC0', 'uri': 'https://creativecommons.org/publicdomain/zero/1.0/'}
+          }
+        },
+        KeyError,
+        id="missing_metadataBlocks_key"
+      ),
+    ]
+  )
+  def test_get_formatted_metadata_message_version_2(self, metadata, expected_output):
+    # Act
+    if isinstance(expected_output, type) and issubclass(expected_output, Exception):
+      with pytest.raises(expected_output):
+        get_formatted_metadata_message(metadata)
+    else:
+      result = get_formatted_metadata_message(metadata)
+
+      # Assert
+      assert result == expected_output
 
   # Test data for error cases
   @pytest.mark.parametrize("metadata,expected_exception, test_id", [

--- a/tests/unit_tests/test_http_client.py
+++ b/tests/unit_tests/test_http_client.py
@@ -92,6 +92,7 @@ class TestAsyncHttpClient(object):
     mock_log_info = mocker.patch.object(http_client_mock.logger, 'info')
     mock_client_session = mocker.patch('aiohttp.client.ClientSession')
     mock_client_response = mocker.patch('aiohttp.client.ClientResponse')
+    mock_client_timeout = mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
     mock_authorization = mocker.MagicMock()
     mock_client_session_constructor = mocker.patch.object(ClientSession, '__aenter__', return_value=mock_client_session)
     mocker.patch.object(mock_client_response, '__aenter__', return_value=mock_client_response)
@@ -112,10 +113,11 @@ class TestAsyncHttpClient(object):
                                       mock_authorization) == response, "Valid results must be returned"
     mock_log_info.assert_any_call("Get url: %s", base_url)
     mock_client_session_constructor.assert_called_once_with()
+    mock_client_timeout.assert_called_once_with(total=http_client_mock.session_timeout)
     mock_client_session_get_response.assert_called_once_with(base_url,
                                                              params=request_params,
                                                              headers=request_headers,
-                                                             timeout=http_client_mock.session_timeout,
+                                                             timeout=mock_client_timeout.return_value,
                                                              auth=mock_authorization)
     mock_client_session_get_response_json.assert_called_once_with()
     mock_client_response.headers.get.assert_called_once_with('Content-Type')
@@ -170,6 +172,7 @@ class TestAsyncHttpClient(object):
     mock_log_error = mocker.patch.object(http_client_mock.logger, 'error')
     mock_client_session = mocker.patch('aiohttp.client.ClientSession')
     mock_client_response = mocker.patch('aiohttp.client.ClientResponse')
+    mock_client_timeout = mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
     mock_auth = mocker.MagicMock()
     mock_client_session_constructor = mocker.patch.object(ClientSession, '__aenter__', return_value=mock_client_session)
     mocker.patch.object(mock_client_response, '__aenter__', return_value=mock_client_response)
@@ -181,13 +184,13 @@ class TestAsyncHttpClient(object):
                                       request_params="request_params",
                                       request_headers="request_headers",
                                       auth=mock_auth,
-                                      timeout=http_client_mock.session_timeout) == {}, "Valid results must be returned"
+                                      timeout=mock_client_timeout.return_value) == {}, "Valid results must be returned"
     http_client_mock.logger.info.assert_any_call("Get url: %s", url)
     mock_client_session_constructor.assert_called_once_with()
     mock_client_session_get_response.assert_called_once_with(url,
                                                              params="request_params",
                                                              headers="request_headers",
-                                                             timeout=http_client_mock.session_timeout,
+                                                             timeout=mock_client_timeout.return_value,
                                                              auth=mock_auth)
     mock_log_error.assert_called_once_with(error_message)
     assert http_client_mock.session_request_errors[
@@ -249,6 +252,7 @@ class TestAsyncHttpClient(object):
     mock_log_error = mocker.patch.object(http_client_mock.logger, 'error')
     mock_client_session = mocker.patch('aiohttp.client.ClientSession')
     mock_client_response = mocker.patch('aiohttp.client.ClientResponse')
+    mock_client_timeout = mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
     mock_client_session_constructor = mocker.patch.object(ClientSession, '__aenter__', return_value=mock_client_session)
     mocker.patch.object(mock_client_response, '__aenter__', return_value=mock_client_response)
     mock_client_session_get_response = mocker.patch.object(mock_client_session, 'post',
@@ -260,13 +264,13 @@ class TestAsyncHttpClient(object):
                                        data=mock_data,
                                        auth=mock_auth,
                                        request_headers=mock_headers,
-                                       timeout=http_client_mock.session_timeout) == {}, "Valid results must be returned"
+                                       timeout=mock_client_timeout.return_value) == {}, "Valid results must be returned"
     mock_log_info.assert_any_call('Post url: %s', url)
     mock_client_session_constructor.assert_called_once_with()
     mock_client_session_get_response.assert_called_once_with(url,
                                                              headers=mock_headers,
                                                              params=mock_params,
-                                                             timeout=http_client_mock.session_timeout,
+                                                             timeout=mock_client_timeout.return_value,
                                                              json=mock_json,
                                                              data=mock_data,
                                                              auth=mock_auth)
@@ -287,6 +291,7 @@ class TestAsyncHttpClient(object):
     mock_log_info = mocker.patch.object(http_client_mock.logger, 'info')
     mock_client_session = mocker.patch('aiohttp.client.ClientSession')
     mock_client_response = mocker.patch('aiohttp.client.ClientResponse')
+    mock_client_timeout = mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
     mock_client_session_constructor = mocker.patch.object(ClientSession, '__aenter__', return_value=mock_client_session)
     mocker.patch.object(mock_client_response, '__aenter__', return_value=mock_client_response)
     mock_client_session_post_response = mocker.patch.object(mock_client_session, 'post',
@@ -305,7 +310,7 @@ class TestAsyncHttpClient(object):
                                       data=mock_data,
                                       auth=mock_auth,
                                       request_headers=mock_headers,
-                                      timeout=http_client_mock.session_timeout)
+                                      timeout=mock_client_timeout.return_value)
     assert ret, "Valid results must be returned"
     assert ret.get("status") == 200, "Response status should be as expected"
     assert ret.get("headers") == mock_client_response.headers, "Response headers should not be none"
@@ -317,7 +322,7 @@ class TestAsyncHttpClient(object):
     mock_client_session_post_response.assert_called_once_with("base_url",
                                                               headers=mock_headers,
                                                               params=mock_params,
-                                                              timeout=http_client_mock.session_timeout,
+                                                              timeout=mock_client_timeout.return_value,
                                                               json=mock_json,
                                                               data=mock_data,
                                                               auth=mock_auth)
@@ -336,6 +341,7 @@ class TestAsyncHttpClient(object):
     mock_auth = mocker.MagicMock()
     mock_client_session = mocker.patch('aiohttp.client.ClientSession')
     mock_client_response = mocker.patch('aiohttp.client.ClientResponse')
+    mock_client_timeout = mocker.patch('pasta_eln.webclient.http_client.ClientTimeout')
     mock_client_session_constructor = mocker.patch.object(ClientSession, '__aenter__', return_value=mock_client_session)
     mocker.patch.object(mock_client_response, '__aenter__', return_value=mock_client_response)
     mock_client_session_delete_response = mocker.patch.object(mock_client_session, 'delete',
@@ -354,7 +360,7 @@ class TestAsyncHttpClient(object):
                                         data=mock_data,
                                         auth=mock_auth,
                                         request_headers=mock_headers,
-                                        timeout=http_client_mock.session_timeout)
+                                        timeout=mock_client_timeout.return_value)
     assert ret, "Valid results must be returned"
     assert ret.get("status") == 200, "Response status should be as expected"
     assert ret.get("headers") == mock_client_response.headers, "Response headers should not be none"
@@ -366,7 +372,7 @@ class TestAsyncHttpClient(object):
     mock_client_session_delete_response.assert_called_once_with("base_url",
                                                                 headers=mock_headers,
                                                                 params=mock_params,
-                                                                timeout=http_client_mock.session_timeout,
+                                                                timeout=mock_client_timeout.return_value,
                                                                 json=mock_json,
                                                                 data=mock_data,
                                                                 auth=mock_auth)


### PR DESCRIPTION
- Added "No Value" option to all the combo box and also to the datetime UI elements; in case when the user does not set any value, default "No Value" will be selected which prohibits the auto selection while switching between the items.
- Added a clear button to clear all the edited UI elements, especially required for clearing the combo-box and datetime elements.
- Other minor refactorings: extracted the add_delete_button and add_clear_button as utility functions for common usage.
- Adapted  and corrected the tests for the changes.