### PR TITLE
fix(dataverse): implement fix for data-verse upload crash 

### DIFF
--- a/pasta_eln/dataverse/generic_task_object.py
+++ b/pasta_eln/dataverse/generic_task_object.py
@@ -12,7 +12,7 @@ import itertools
 import logging
 
 from PySide6 import QtCore
-from PySide6.QtCore import QObject
+from PySide6.QtCore import QObject, Qt
 
 
 class GenericTaskObject(QObject):
@@ -49,8 +49,8 @@ class GenericTaskObject(QObject):
     self.started = False
     self.cleaned = False
     self.finished = False
-    self.cancel.connect(lambda: self.cancel_task())  # pylint: disable=unnecessary-lambda
-    self.finish.connect(lambda: self.finish_task())  # pylint: disable=unnecessary-lambda
+    self.cancel.connect(self.cancel_task, type=Qt.DirectConnection)  # type: ignore[attr-defined]
+    self.finish.connect(self.finish_task, type=Qt.DirectConnection)  # type: ignore[attr-defined]
     self.start.connect(self.start_task)
 
   def cancel_task(self) -> None:
@@ -95,9 +95,6 @@ class GenericTaskObject(QObject):
     """
     self.logger.info("Cleaning up task, id: %s", self.id)
     self.cleaned = True
-    self.cancel.disconnect()
-    self.finish.disconnect()
-    self.start.disconnect()
 
   def finish_task(self) -> None:
     """

--- a/pasta_eln/dataverse/upload_queue_manager.py
+++ b/pasta_eln/dataverse/upload_queue_manager.py
@@ -11,7 +11,7 @@ import logging
 from time import sleep
 
 from PySide6 import QtCore
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import Qt
 
 from pasta_eln.dataverse.config_model import ConfigModel
 from pasta_eln.dataverse.database_api import DatabaseAPI
@@ -54,8 +54,8 @@ class UploadQueueManager(GenericTaskObject):
     self.upload_queue: list[TaskThreadExtension] = []
     self.running_queue: list[TaskThreadExtension] = []
     self.db_api: DatabaseAPI = DatabaseAPI()
-    self.cancel_all_tasks.connect(
-      lambda: self.cancel_all_queued_tasks_and_empty_queue())  # pylint: disable=unnecessary-lambda
+    self.cancel_all_tasks.connect(self.cancel_all_queued_tasks_and_empty_queue,
+                                  type=Qt.DirectConnection)  # type: ignore[attr-defined]
     self.set_concurrent_uploads()
 
   def set_concurrent_uploads(self) -> None:
@@ -65,10 +65,6 @@ class UploadQueueManager(GenericTaskObject):
     Explanation:
         This method retrieves the number of concurrent uploads from the database and sets it as the value for the
         number_of_concurrent_uploads attribute.
-
-    Args:
-        None
-
     """
     self.logger.info("Resetting number of concurrent uploads..")
     self.config_model = self.db_api.get_config_model()
@@ -211,4 +207,4 @@ class UploadQueueManager(GenericTaskObject):
     for upload_task_thread in self.upload_queue:
       upload_task_thread.task.cancel.emit()
     if self.upload_queue:
-      QTimer.singleShot(500, lambda: self.remove_cancelled_tasks())  # pylint: disable=unnecessary-lambda
+      self.remove_cancelled_tasks()

--- a/tests/unit_tests/test_dataverse_generic_task_object.py
+++ b/tests/unit_tests/test_dataverse_generic_task_object.py
@@ -119,9 +119,6 @@ class TestDataverseGenericTaskObject:
     # Assert
     assert task.cleaned == expected_cleaned_state, f"Test ID {test_id}: Expected cleaned state to be {expected_cleaned_state}"
     mock_logger.info.assert_called_once_with('Cleaning up task, id: %s', setup_id)
-    task.cancel.disconnect.assert_called_once()
-    task.finish.disconnect.assert_called_once()
-    task.start.disconnect.assert_called_once()
 
   @pytest.mark.parametrize("test_id, initial_finished, expected_finished", [  # Success path tests
     ("success_case_1", False, True),  # Cleaning up task from non-cleaned state

--- a/tests/unit_tests/test_dataverse_upload_queue_manager.py
+++ b/tests/unit_tests/test_dataverse_upload_queue_manager.py
@@ -439,8 +439,8 @@ class TestDataverseUploadQueueManager:
   def test_cancel_all_queued_tasks_and_empty_queue(self, mocker, mock_manager, test_id, upload_queue_size):
     # Arrange
     mock_manager.upload_queue = [MagicMock() for _ in range(upload_queue_size)]
-    mock_manager.remove_cancelled_tasks = MagicMock()
-    mocked_timer = mocker.patch('pasta_eln.dataverse.upload_queue_manager.QTimer.singleShot')
+    mock_manager.remove_cancelled_tasks = mocker.MagicMock()
+    mock_manager.remove_cancelled_tasks = mocker.MagicMock()
     # Act
     mock_manager.cancel_all_queued_tasks_and_empty_queue()
 
@@ -449,7 +449,7 @@ class TestDataverseUploadQueueManager:
     for task in mock_manager.upload_queue:
       task.task.cancel.emit.assert_called_once()
     if upload_queue_size > 0:
-      mocked_timer.assert_called_once_with(500, mocker.ANY)
+      mock_manager.remove_cancelled_tasks.assert_called_once()
     else:
-      mocked_timer.assert_not_called()
+      mock_manager.remove_cancelled_tasks.assert_not_called()
     mock_manager.logger.info.assert_called_once()


### PR DESCRIPTION
- Removed signal disconnect calls which leads to segmentation fault with the latest version of pyside6.
- Connected finish and cancel signals with respective slots via DirectConnection for the slots to be executed in the calling thread itself(just flipping the respective flags used inside the threads).